### PR TITLE
courseFilter adjustments

### DIFF
--- a/scripts/courseFilter.py
+++ b/scripts/courseFilter.py
@@ -7,7 +7,7 @@ def courseFilter():
     f.close()
 
     # Sort by course code
-    courses.sort(key=lambda x: x['code'])
+    courses.sort(key=lambda x: (x['code'] + x['title']))
 
     filteredCourses = []
     c = (0, 0, 0, 0)
@@ -16,11 +16,11 @@ def courseFilter():
     for course in courses:
         # Read next course
         newC = (course['code'], course['title'], course['campus'], course['credits'])
-        if newC[0] == c[0] and newC[2] == 'hmc':
+        if newC[0] == c[0] and newC[1] == c[1] and newC[2] == 'hmc':
             # If course duplicate, keep the HMC course
             
             c = newC
-        elif newC[0] != c[0] and c[0] != 0:
+        elif (newC[0] != c[0] or newC[1] != c[1]) and c[0] != 0:
             # If newC is a new, valid course, add new course to fildterCourses
             if not any(i.islower() for i in str(c[0])):
                 newCourse = {'code': c[0], 'title': c[1], 'campus': c[2], 'credits': c[3]}

--- a/scripts/courseFilter.py
+++ b/scripts/courseFilter.py
@@ -18,6 +18,7 @@ def courseFilter():
         newC = (course['code'], course['title'], course['campus'], course['credits'])
         if newC[0] == c[0] and newC[2] == 'hmc':
             # If course duplicate, keep the HMC course
+            
             c = newC
         elif newC[0] != c[0] and c[0] != 0:
             # If newC is a new, valid course, add new course to fildterCourses
@@ -25,7 +26,7 @@ def courseFilter():
                 newCourse = {'code': c[0], 'title': c[1], 'campus': c[2], 'credits': c[3]}
                 filteredCourses.append(newCourse)
             c = newC
-        else:
+        elif c[0] == 0:
             c = newC
 
     # Add in the last course if valid

--- a/src/static/allCourses.json
+++ b/src/static/allCourses.json
@@ -7,6 +7,12 @@
   },
   {
     "code": "AAA100",
+    "title": "Test Class--Ignore",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "AAA100",
     "title": "Test Course I",
     "campus": "pz",
     "credits": 3.0
@@ -204,15 +210,21 @@
     "credits": 3.0
   },
   {
+    "code": "AFRI144A",
+    "title": "Black Women, Feminism(s) & Arts",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "AFRI149",
-    "title": "Black Political Theory in the US",
+    "title": "Africana Political Theory",
     "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "AFRI150",
-    "title": "Special Topics: Africana Studies",
-    "campus": "cmc",
+    "code": "AFRI149",
+    "title": "Black Political Theory in the US",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -222,15 +234,33 @@
     "credits": 3.0
   },
   {
+    "code": "AFRI150",
+    "title": "Special Topics: Africana Studies",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "AFRI190",
     "title": "Senior Seminar",
     "campus": "po",
     "credits": 3.0
   },
   {
+    "code": "AFRI190",
+    "title": "Senior Thesis",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "AFRI191",
     "title": "Senior Thesis",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "AFRI191",
+    "title": "Senior Thesis:Africana Studies",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -288,12 +318,6 @@
     "credits": 3.0
   },
   {
-    "code": "AFRI199",
-    "title": "Independent Study in Africana St",
-    "campus": "sc",
-    "credits": 3.0
-  },
-  {
     "code": "AFRI199DRAF",
     "title": "Africana St: Directed Readings",
     "campus": "po",
@@ -303,6 +327,18 @@
     "code": "AFRI199IRAF",
     "title": "Africana St: Indep Research",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "AFRI199",
+    "title": "Independent Study & Research",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "AFRI199",
+    "title": "Independent Study in Africana St",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -378,12 +414,6 @@
     "credits": 3.0
   },
   {
-    "code": "ALS400",
-    "title": "Team Masters Project",
-    "campus": "cgu",
-    "credits": 3.0
-  },
-  {
     "code": "ALS400A",
     "title": "Team Masters Project",
     "campus": "cgu",
@@ -397,6 +427,12 @@
   },
   {
     "code": "ALS400C",
+    "title": "Team Masters Project",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "ALS400",
     "title": "Team Masters Project",
     "campus": "cgu",
     "credits": 3.0
@@ -540,15 +576,15 @@
     "credits": 3.0
   },
   {
-    "code": "AMST190",
-    "title": "Senior Thesis Seminar",
-    "campus": "sc",
+    "code": "AMST180",
+    "title": "Seminar in American Studies",
+    "campus": "pz",
     "credits": 3.0
   },
   {
-    "code": "AMST191",
-    "title": "Senior Thesis",
-    "campus": "po",
+    "code": "AMST190",
+    "title": "Senior Thesis Seminar",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -560,6 +596,18 @@
   {
     "code": "AMST191H",
     "title": "Honors Sr Thesis: American St",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "AMST191",
+    "title": "Senior Thesis",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "AMST191",
+    "title": "Senior Thesis: American Studies",
     "campus": "sc",
     "credits": 3.0
   },
@@ -576,12 +624,6 @@
     "credits": 3.0
   },
   {
-    "code": "AMST199",
-    "title": "Independent St: American Studies",
-    "campus": "sc",
-    "credits": 3.0
-  },
-  {
     "code": "AMST199DRPO",
     "title": "American St: Directed Readings",
     "campus": "po",
@@ -591,6 +633,12 @@
     "code": "AMST199IRPO",
     "title": "American St: Indep Research",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "AMST199",
+    "title": "Independent St: American Studies",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -608,6 +656,12 @@
   {
     "code": "ANTH001",
     "title": "Intro Archaeology & Bio Anthro",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH002",
+    "title": "Intro Sociocultural Anthropology",
     "campus": "pz",
     "credits": 3.0
   },
@@ -655,13 +709,13 @@
   },
   {
     "code": "ANTH020",
-    "title": "Human Histories:Onset to 1500ish",
-    "campus": "pz",
+    "title": "Anthropology of Latin America",
+    "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "ANTH021",
-    "title": "The World Since 1492",
+    "code": "ANTH020",
+    "title": "Human Histories:Onset to 1500ish",
     "campus": "pz",
     "credits": 3.0
   },
@@ -672,9 +726,21 @@
     "credits": 3.0
   },
   {
+    "code": "ANTH021",
+    "title": "The World Since 1492",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "ANTH023",
     "title": "China/Japn thru Film/Ethnography",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH025",
+    "title": "Anthro of the Middle East",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -751,8 +817,20 @@
   },
   {
     "code": "ANTH047",
+    "title": "Anthropology of Religion",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH047",
     "title": "Economic Anthropology",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH047",
+    "title": "Language, Identity and Violence",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -786,6 +864,18 @@
     "credits": 3.0
   },
   {
+    "code": "ANTH052",
+    "title": "Indigenous Societies",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH053",
+    "title": "Language and Globalization",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "ANTH053",
     "title": "Language, Thought, and Culture",
     "campus": "po",
@@ -793,8 +883,20 @@
   },
   {
     "code": "ANTH055",
+    "title": "Brazil: An Introduction",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH055",
     "title": "Power, Politics & Culture",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH056",
+    "title": "Anthropology of Sound",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -837,6 +939,12 @@
     "code": "ANTH068",
     "title": "Life Online",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH068",
+    "title": "Life Online: Cultr,Tech,Democ",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -949,6 +1057,12 @@
   },
   {
     "code": "ANTH098",
+    "title": "Palestine and Israel",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH098",
     "title": "State & History:The Israeli Case",
     "campus": "pz",
     "credits": 3.0
@@ -967,6 +1081,12 @@
   },
   {
     "code": "ANTH101",
+    "title": "Archaeological Theory",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH101",
     "title": "Theory & Method in Archaeology",
     "campus": "pz",
     "credits": 3.0
@@ -978,8 +1098,8 @@
     "credits": 3.0
   },
   {
-    "code": "ANTH103",
-    "title": "Museums: Behind the Glass",
+    "code": "ANTH102",
+    "title": "Museums and Material Culture",
     "campus": "pz",
     "credits": 3.0
   },
@@ -990,8 +1110,20 @@
     "credits": 3.0
   },
   {
+    "code": "ANTH103",
+    "title": "Museums: Behind the Glass",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "ANTH104",
     "title": "Anth Perspectives/Migration&Dias",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH105",
+    "title": "Field Methods in Anthropology",
     "campus": "pz",
     "credits": 3.0
   },
@@ -1009,14 +1141,32 @@
   },
   {
     "code": "ANTH107",
+    "title": "Medical Anthro & Global Health",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH107",
     "title": "Medical Anthropology",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH107",
+    "title": "The Social Life of Statistics",
+    "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "ANTH108",
     "title": "Kinship & Social Organization",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH108",
+    "title": "Kinship, Family, Sexuality",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -1027,8 +1177,44 @@
   },
   {
     "code": "ANTH110",
+    "title": "Archaeological Methods",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH110",
+    "title": "Field Methods in Archaeology",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH110",
     "title": "Knowledge,Belief,Cultural Practs",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH110",
+    "title": "Life: Knowledge and Practices",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH110",
+    "title": "Nature and Society in Amazonia",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH111",
+    "title": "Archaeological Field Practicum",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH111",
+    "title": "Historical Archaeology",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -1039,8 +1225,20 @@
   },
   {
     "code": "ANTH112",
+    "title": "Energy & Humnty, Past, Prsnt, Ft",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH112",
     "title": "Intro to China, Tibet & Nepal",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH112",
+    "title": "Lab Methods in Archaeology",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -1052,6 +1250,18 @@
   {
     "code": "ANTH114",
     "title": "Science, Medicine & Colonialism",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH115",
+    "title": "Global Latin America",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH115",
+    "title": "Stuff:Social Life of Commodities",
     "campus": "sc",
     "credits": 3.0
   },
@@ -1086,6 +1296,12 @@
     "credits": 3.0
   },
   {
+    "code": "ANTH119",
+    "title": "East Asia in Ethnography & Film",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ANTH120",
     "title": "Studying Up",
     "campus": "pz",
@@ -1098,6 +1314,18 @@
     "credits": 3.0
   },
   {
+    "code": "ANTH121",
+    "title": "Science, Medicine, Technology",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH122",
+    "title": "Cooperative Filmmaking for Socia",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "ANTH122",
     "title": "Research Apprenticeship",
     "campus": "pz",
@@ -1106,6 +1334,12 @@
   {
     "code": "ANTH123",
     "title": "Anthropology & Globalization",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH124",
+    "title": "Illness/Health: Anthro Perspect",
     "campus": "pz",
     "credits": 3.0
   },
@@ -1134,8 +1368,20 @@
     "credits": 3.0
   },
   {
+    "code": "ANTH127",
+    "title": "Settler Colonialism",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ANTH128",
     "title": "Refugees, Migrants, Citizenship",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH129",
+    "title": "Gender, Nationalisms & the State",
     "campus": "sc",
     "credits": 3.0
   },
@@ -1146,9 +1392,27 @@
     "credits": 3.0
   },
   {
+    "code": "ANTH129",
+    "title": "Politics of Public Art",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH130",
+    "title": "Anthro of Gender and Health",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ANTH130",
     "title": "Sexuality/Sexual Poli Mid-East",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH130",
+    "title": "Women and Citizenship",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -1165,6 +1429,12 @@
   },
   {
     "code": "ANTH133",
+    "title": "Colonialism & Postcol Theory",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH133",
     "title": "Indians in Action",
     "campus": "pz",
     "credits": 3.0
@@ -1173,6 +1443,12 @@
     "code": "ANTH134",
     "title": "Rationalities",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH135",
+    "title": "Plants and Peoples",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -1213,6 +1489,12 @@
   },
   {
     "code": "ANTH142",
+    "title": "Culture & Politics Latin America",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH142",
     "title": "Ethnographic Approaches to Japan",
     "campus": "po",
     "credits": 3.0
@@ -1230,9 +1512,21 @@
     "credits": 3.0
   },
   {
+    "code": "ANTH145",
+    "title": "Mesoamerican Archaeology",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "ANTH149",
     "title": "Anthro of the (Extra)Ordinary",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH150",
+    "title": "Anthropology of Religion",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -1255,6 +1549,18 @@
   },
   {
     "code": "ANTH153",
+    "title": "Anthropological Theory",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH153",
+    "title": "History Anthropological Theory",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH153",
     "title": "Theory in Anthropology",
     "campus": "po",
     "credits": 3.0
@@ -1263,6 +1569,12 @@
     "code": "ANTH155",
     "title": "Globalization",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH155",
+    "title": "World Nexus: Special Topic",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -1296,9 +1608,21 @@
     "credits": 3.0
   },
   {
+    "code": "ANTH160",
+    "title": "Native American Women's Arts",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "ANTH161",
     "title": "Experimental Archaeology",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH161",
+    "title": "Greek Art and Archaeology",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -1316,6 +1640,12 @@
   {
     "code": "ANTH165",
     "title": "The American Sixties",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH168",
+    "title": "Prehist Humans and Environments",
     "campus": "pz",
     "credits": 3.0
   },
@@ -1344,12 +1674,6 @@
     "credits": 3.0
   },
   {
-    "code": "ANTH179",
-    "title": "Special Topics in Anthropology",
-    "campus": "hmc",
-    "credits": 3.0
-  },
-  {
     "code": "ANTH179A",
     "title": "Infants/Children: Unequal World",
     "campus": "hmc",
@@ -1364,6 +1688,12 @@
   {
     "code": "ANTH179D",
     "title": "Global Inequality/Children/Inven",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH179",
+    "title": "Special Topics in Anthropology",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -1388,6 +1718,12 @@
   {
     "code": "ANTH189H",
     "title": "Economic Anthropology",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH189L",
+    "title": "Linguistic Anthropology",
     "campus": "po",
     "credits": 3.0
   },
@@ -1422,15 +1758,21 @@
     "credits": 3.0
   },
   {
-    "code": "ANTH191",
-    "title": "Senior Thesis",
-    "campus": "po",
+    "code": "ANTH190",
+    "title": "Senior Seminar",
+    "campus": "sc",
     "credits": 3.0
   },
   {
     "code": "ANTH191A",
     "title": "Senior Thesis: Sociocultural",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH191A",
+    "title": "Sr Thesis: Sociocultural Track",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -1446,15 +1788,27 @@
     "credits": 3.0
   },
   {
+    "code": "ANTH191",
+    "title": "Senior Thesis",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH191",
+    "title": "Senior Thesis Seminar",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ANTH192",
     "title": "Senior Project",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "ANTH197",
-    "title": "Independent Study: Anthropology",
-    "campus": "hmc",
+    "code": "ANTH192",
+    "title": "Senior Thesis & Project Seminar",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -1476,6 +1830,12 @@
     "credits": 3.0
   },
   {
+    "code": "ANTH197",
+    "title": "Independent Study: Anthropology",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "ANTH197L",
     "title": "Visual Anthropology",
     "campus": "sc",
@@ -1494,12 +1854,6 @@
     "credits": 3.0
   },
   {
-    "code": "ANTH199",
-    "title": "Senior Thesis",
-    "campus": "pz",
-    "credits": 3.0
-  },
-  {
     "code": "ANTH199DRPO",
     "title": "Anthropology: Directed Readings",
     "campus": "po",
@@ -1512,9 +1866,21 @@
     "credits": 3.0
   },
   {
+    "code": "ANTH199",
+    "title": "Independent St: Anthropology",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ANTH199RAPO",
     "title": "Anthropology: Research Asstship",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ANTH199",
+    "title": "Senior Thesis",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -1717,6 +2083,12 @@
   },
   {
     "code": "ARCN101",
+    "title": "Art Consv & Cultural Sustain",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ARCN101",
     "title": "Intro to Art Conservation",
     "campus": "sc",
     "credits": 3.0
@@ -1724,6 +2096,18 @@
   {
     "code": "ARCN110",
     "title": "Artists Materials,Ancient+Modern",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ARCN110",
+    "title": "Artists Materials:Ancient/Modern",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ARCN115",
+    "title": "Art & Crime: Fakes & Forensics",
     "campus": "sc",
     "credits": 3.0
   },
@@ -1855,6 +2239,12 @@
   },
   {
     "code": "ARHI051C",
+    "title": "Intro Art Hist: 1200 to Present",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ARHI051C",
     "title": "Intro Art Hist:Rnsscnce to Mod",
     "campus": "po",
     "credits": 3.0
@@ -1903,6 +2293,12 @@
   },
   {
     "code": "ARHI131",
+    "title": "Border Art",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ARHI131",
     "title": "History of Landscape Photography",
     "campus": "hmc",
     "credits": 3.0
@@ -1917,6 +2313,12 @@
     "code": "ARHI133",
     "title": "Art, Conquest and Colonization",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ARHI133",
+    "title": "Indians in Action",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -1938,14 +2340,14 @@
     "credits": 3.0
   },
   {
-    "code": "ARHI138",
-    "title": "Native Amer Art Collections Rsch",
+    "code": "ARHI138B",
+    "title": "Native Am Art Collections & Lab",
     "campus": "pz",
     "credits": 3.0
   },
   {
-    "code": "ARHI138B",
-    "title": "Native Am Art Collections & Lab",
+    "code": "ARHI138",
+    "title": "Native Amer Art Collections Rsch",
     "campus": "pz",
     "credits": 3.0
   },
@@ -1998,6 +2400,12 @@
     "credits": 3.0
   },
   {
+    "code": "ARHI150",
+    "title": "The Arts of China",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ARHI151",
     "title": "The Arts of Japan",
     "campus": "sc",
@@ -2017,8 +2425,20 @@
   },
   {
     "code": "ARHI154",
+    "title": "Japanese Prints",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ARHI154",
     "title": "Modern Art 1950-1970",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ARHI154",
+    "title": "Modern Asian Prints",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -2088,6 +2508,12 @@
     "credits": 3.0
   },
   {
+    "code": "ARHI166",
+    "title": "Crusades:Cross-Cultural History",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "ARHI167",
     "title": "Town/Castle/Cathedral in France",
     "campus": "po",
@@ -2136,6 +2562,12 @@
     "credits": 3.0
   },
   {
+    "code": "ARHI176",
+    "title": "Neo-Classicism to Impressionism",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ARHI177",
     "title": "18th Century European Arts",
     "campus": "sc",
@@ -2145,12 +2577,6 @@
     "code": "ARHI178",
     "title": "Black Aesth/Poli (Re)presentatn",
     "campus": "po",
-    "credits": 3.0
-  },
-  {
-    "code": "ARHI179",
-    "title": "Special Topics in Art History",
-    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -2172,6 +2598,24 @@
     "credits": 3.0
   },
   {
+    "code": "ARHI179",
+    "title": "Modern Arch/Sustainability",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ARHI179",
+    "title": "Special Topics in Art History",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ARHI180",
+    "title": "Archi Models Monuments Miniature",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ARHI180",
     "title": "Early 20C European Avant-Gardes",
     "campus": "sc",
@@ -2185,8 +2629,20 @@
   },
   {
     "code": "ARHI181",
+    "title": "Art from 1945-1989",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ARHI181",
     "title": "Modern Into Contemporary",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ARHI181",
+    "title": "Modern into Contemporary Art",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -2220,15 +2676,21 @@
     "credits": 3.0
   },
   {
-    "code": "ARHI186",
-    "title": "Seminar in 20th Century Art",
-    "campus": "sc",
-    "credits": 3.0
-  },
-  {
     "code": "ARHI186A",
     "title": "Theories of Contemporary Art",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ARHI186B",
+    "title": "Art and Animals",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ARHI186B",
+    "title": "Topics Contemp Art and Animals",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -2286,9 +2748,27 @@
     "credits": 3.0
   },
   {
+    "code": "ARHI186K",
+    "title": "Seminar in Mod Art: The Bauhaus",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ARHI186K",
+    "title": "Seminar in Modern Art",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ARHI186L",
     "title": "Critical Race Thry/Representatn",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ARHI186L",
+    "title": "Seminar: The Artist",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -2316,8 +2796,26 @@
     "credits": 3.0
   },
   {
+    "code": "ARHI186",
+    "title": "Seminar in 20th Century Art",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ARHI186T",
     "title": "Art and Time",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ARHI186T",
+    "title": "THINGS",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ARHI186W",
+    "title": "Interrog Whiteness:Race,Sex,Rep",
     "campus": "po",
     "credits": 3.0
   },
@@ -2347,6 +2845,12 @@
   },
   {
     "code": "ARHI189",
+    "title": "European Modernism",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ARHI189",
     "title": "European Modernism 1840-1940",
     "campus": "sc",
     "credits": 3.0
@@ -2370,9 +2874,9 @@
     "credits": 3.0
   },
   {
-    "code": "ARHI191",
-    "title": "Senior Thesis - Art History",
-    "campus": "po",
+    "code": "ARHI190",
+    "title": "Senior Seminar in Art History",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -2388,6 +2892,18 @@
     "credits": 3.0
   },
   {
+    "code": "ARHI191",
+    "title": "Senior Thesis - Art History",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ARHI191",
+    "title": "Senior Thesis in Art History",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "ARHI197",
     "title": "Independent Study: Art History",
     "campus": "hmc",
@@ -2395,14 +2911,14 @@
   },
   {
     "code": "ARHI198",
-    "title": "Summer Reading & Research",
-    "campus": "po",
+    "title": "Independent Internship",
+    "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "ARHI199",
-    "title": "Independent Study in Art History",
-    "campus": "sc",
+    "code": "ARHI198",
+    "title": "Summer Reading & Research",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -2415,6 +2931,12 @@
     "code": "ARHI199IRPO",
     "title": "Art History: Indep Research",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ARHI199",
+    "title": "Independent Study in Art History",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -2490,12 +3012,6 @@
     "credits": 3.0
   },
   {
-    "code": "ART",
-    "title": "Art: Directed Readings",
-    "campus": "po",
-    "credits": 3.0
-  },
-  {
     "code": "ART001",
     "title": "Introduction to Studio Art",
     "campus": "pz",
@@ -2551,6 +3067,12 @@
   },
   {
     "code": "ART020",
+    "title": "A Philosopher & An Artist",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ART020",
     "title": "Black and White Photography",
     "campus": "po",
     "credits": 3.0
@@ -2586,14 +3108,20 @@
     "credits": 3.0
   },
   {
+    "code": "ART029B",
+    "title": "Metals: The Alchemy of...",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "ART029",
     "title": "Introduction to Metal Casting",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "ART029B",
-    "title": "Metals: The Alchemy of...",
+    "code": "ART033",
+    "title": "Fiber Studio",
     "campus": "po",
     "credits": 3.0
   },
@@ -2652,12 +3180,6 @@
     "credits": 3.0
   },
   {
-    "code": "ART100",
-    "title": "Studio Art: Theory, Hist, Pract",
-    "campus": "sc",
-    "credits": 3.0
-  },
-  {
     "code": "ART100A",
     "title": "Introduction to Studio Art",
     "campus": "sc",
@@ -2670,9 +3192,21 @@
     "credits": 3.0
   },
   {
+    "code": "ART100",
+    "title": "Studio Art: Theory, Hist, Pract",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ART101",
     "title": "Further Works in Mixed Media",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ART101",
+    "title": "Introduction to Painting",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -2694,12 +3228,6 @@
     "credits": 3.0
   },
   {
-    "code": "ART105",
-    "title": "Introduction to Drawing",
-    "campus": "sc",
-    "credits": 3.0
-  },
-  {
     "code": "ART105A",
     "title": "Drawing II: Abstractions",
     "campus": "po",
@@ -2709,6 +3237,18 @@
     "code": "ART105B",
     "title": "Drawing II: Representation",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ART105",
+    "title": "Introduction to Drawing",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ART105",
+    "title": "The Surfboard as Art & Culture",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -2731,6 +3271,12 @@
   },
   {
     "code": "ART109",
+    "title": "Adobe & Brick Oven Construction",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ART109",
     "title": "Painting as Experiment",
     "campus": "po",
     "credits": 3.0
@@ -2738,6 +3284,12 @@
   {
     "code": "ART110",
     "title": "Drawing: Materials Workshop",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ART111",
+    "title": "Intermediate Painting",
     "campus": "pz",
     "credits": 3.0
   },
@@ -2755,6 +3307,12 @@
   },
   {
     "code": "ART113",
+    "title": "Adv Mixed Media: Sci & Landscape",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ART113",
     "title": "Drawing Workshop",
     "campus": "pz",
     "credits": 3.0
@@ -2762,6 +3320,18 @@
   {
     "code": "ART114",
     "title": "Figure Painting",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ART114",
+    "title": "Printmaking Studio",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ART115",
+    "title": "Food and Painting",
     "campus": "pz",
     "credits": 3.0
   },
@@ -2778,6 +3348,12 @@
     "credits": 3.0
   },
   {
+    "code": "ART116",
+    "title": "Moldmaking",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "ART117",
     "title": "Further Works in Ceramics",
     "campus": "pz",
@@ -2791,7 +3367,13 @@
   },
   {
     "code": "ART119",
-    "title": "Landscape/Placescape/Spacescape",
+    "title": "(un)Sustainable Art and Design",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ART119",
+    "title": "Further Explorations: B&W Photo",
     "campus": "po",
     "credits": 3.0
   },
@@ -2802,9 +3384,45 @@
     "credits": 3.0
   },
   {
+    "code": "ART119",
+    "title": "Landscape/Placescape/Spacescape",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ART119",
+    "title": "The Ceramic Object and Food",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ART120",
+    "title": "Introduction to B&W Photography",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ART120",
+    "title": "Introduction to Wheel Throwing",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ART120",
     "title": "Photographing People",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ART121",
+    "title": "Critical Design Studio",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ART121",
+    "title": "Dark Arts: Photography & Chance",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -2814,8 +3432,32 @@
     "credits": 3.0
   },
   {
+    "code": "ART121",
+    "title": "Waiting for the Sun: Photo & Dis",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "ART122",
     "title": "Intermediate & Advanced Ceramics",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ART122",
+    "title": "Photography Lab Practicum",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ART122",
+    "title": "Photography at Night",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ART122",
+    "title": "Systems:Expanded Ceramic Process",
     "campus": "sc",
     "credits": 3.0
   },
@@ -2826,9 +3468,27 @@
     "credits": 3.0
   },
   {
+    "code": "ART123",
+    "title": "Figurative Ceramic Sculpture",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ART124",
+    "title": "Documenting Change with Clay",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ART124",
     "title": "Sound Art",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ART124",
+    "title": "Text & Image Workshop",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -2838,9 +3498,15 @@
     "credits": 3.0
   },
   {
-    "code": "ART126",
-    "title": "Spcl Tpcs: Lrge Frmt Photography",
-    "campus": "pz",
+    "code": "ART125",
+    "title": "Sculpture",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ART125",
+    "title": "Topics In Video Art",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -2850,9 +3516,27 @@
     "credits": 3.0
   },
   {
-    "code": "ART127",
-    "title": "Sculpture Practicum",
+    "code": "ART126",
+    "title": "Intermediate Sculpture",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ART126",
+    "title": "Spcl Tpcs: Lrge Frmt Photography",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ART126",
+    "title": "Special Topics: Photography",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ART127",
+    "title": "Advanced Sculpture",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -2862,9 +3546,45 @@
     "credits": 3.0
   },
   {
+    "code": "ART127",
+    "title": "Inter/Adv Sculpture Practicum",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ART127",
+    "title": "Sculpture Practicum",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ART127",
+    "title": "The Chair",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "ART128",
     "title": "Installation:Site, Time, Context",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ART128",
+    "title": "Three-Dimensional Art",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ART129",
+    "title": "Advanced B&W Photography Seminar",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ART129",
+    "title": "Clay and Public Space",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -2880,14 +3600,38 @@
     "credits": 3.0
   },
   {
+    "code": "ART130",
+    "title": "Clay/Collaboration/Cooperation",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ART130",
+    "title": "Design/Build Studio",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "ART131",
-    "title": "Sculptural Funct & Concep Design",
-    "campus": "po",
+    "title": "Beginning Printmaking",
+    "campus": "sc",
     "credits": 3.0
   },
   {
     "code": "ART131C",
     "title": "Func, Sculpt, Concept, Design",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ART131",
+    "title": "Mixing It Up",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ART131",
+    "title": "Sculptural Funct & Concep Design",
     "campus": "po",
     "credits": 3.0
   },
@@ -2899,6 +3643,12 @@
   },
   {
     "code": "ART133",
+    "title": "Advanced Printmaking",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ART133",
     "title": "Mural Painting",
     "campus": "pz",
     "credits": 3.0
@@ -2906,6 +3656,12 @@
   {
     "code": "ART134",
     "title": "Between Analog+Digital Printmkng",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ART135",
+    "title": "Letterpress Printing",
     "campus": "sc",
     "credits": 3.0
   },
@@ -2923,7 +3679,19 @@
   },
   {
     "code": "ART137",
+    "title": "Book Arts & Social Justice",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ART137",
     "title": "Race & Identity: Artists' Books",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ART137",
+    "title": "Social Justice & Book Arts",
     "campus": "sc",
     "credits": 3.0
   },
@@ -2959,6 +3727,12 @@
   },
   {
     "code": "ART143",
+    "title": "Adv Digital Art",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ART143",
     "title": "Int & Adv Digital Photography",
     "campus": "sc",
     "credits": 3.0
@@ -2966,6 +3740,12 @@
   {
     "code": "ART144",
     "title": "Advanced Web Projects",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ART145",
+    "title": "Intro B/W Darkroom Photo",
     "campus": "sc",
     "credits": 3.0
   },
@@ -2988,8 +3768,20 @@
     "credits": 3.0
   },
   {
+    "code": "ART147",
+    "title": "Int/Adv Digital Photography",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ART148",
     "title": "Introduction to Video Art",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ART149",
+    "title": "Intermediate Video Art",
     "campus": "sc",
     "credits": 3.0
   },
@@ -3042,12 +3834,6 @@
     "credits": 3.0
   },
   {
-    "code": "ART179",
-    "title": "Special Topics in Art",
-    "campus": "hmc",
-    "credits": 3.0
-  },
-  {
     "code": "ART179D",
     "title": "Fluidity: Art, Science & Images",
     "campus": "hmc",
@@ -3078,15 +3864,15 @@
     "credits": 3.0
   },
   {
-    "code": "ART180",
-    "title": "Environmental Robotics",
-    "campus": "pz",
+    "code": "ART179",
+    "title": "Special Topics in Art",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
-    "code": "ART181",
-    "title": "Topics Seminar in Studio Art",
-    "campus": "sc",
+    "code": "ART180",
+    "title": "Environmental Robotics",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -3109,6 +3895,12 @@
   },
   {
     "code": "ART181G",
+    "title": "Beauty & Abject: Race/Gender/Art",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ART181G",
     "title": "From Beauty to the Abject",
     "campus": "sc",
     "credits": 3.0
@@ -3122,6 +3914,18 @@
   {
     "code": "ART181N",
     "title": "Contemp Pract: Artists in L.A.",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ART181",
+    "title": "Research & Writing In The Arts",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ART181",
+    "title": "Topics Seminar in Studio Art",
     "campus": "sc",
     "credits": 3.0
   },
@@ -3168,8 +3972,26 @@
     "credits": 3.0
   },
   {
+    "code": "ART192",
+    "title": "Sr Project & Seminar:Studio Arts",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ART193",
     "title": "Adv Sr Proj+Sem in Studio Art",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ART193",
+    "title": "Advanced Senior Project in Art",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ART193",
+    "title": "Senior Thesis in Art",
     "campus": "sc",
     "credits": 3.0
   },
@@ -3186,6 +4008,18 @@
     "credits": 3.0
   },
   {
+    "code": "ART196",
+    "title": "Curatorial Apprenticeship",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ART197",
+    "title": "Art in Los Angeles Now",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "ART197",
     "title": "Independent Study: Art",
     "campus": "hmc",
@@ -3194,6 +4028,12 @@
   {
     "code": "ART198",
     "title": "Independent Internship",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ART199",
+    "title": "Independent Study:  Studio Arts",
     "campus": "sc",
     "credits": 3.0
   },
@@ -3252,6 +4092,24 @@
     "credits": 3.0
   },
   {
+    "code": "ART",
+    "title": "Art: Directed Readings",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ART",
+    "title": "Art: Independent Research",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ART",
+    "title": "Art: Research Assistantship",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "ARTBUS302CG",
     "title": "Art Law II",
     "campus": "cgu",
@@ -3270,6 +4128,12 @@
     "credits": 3.0
   },
   {
+    "code": "ASAM022",
+    "title": "Healing Justice",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "ASAM023",
     "title": "China/Japn Thru Film/Ethnography",
     "campus": "pz",
@@ -3282,14 +4146,14 @@
     "credits": 3.0
   },
   {
-    "code": "ASAM077",
-    "title": "Tattoos in American Pop Culture",
+    "code": "ASAM077B",
+    "title": "Tattoos:Aesthetics,Culture,Pasts",
     "campus": "pz",
     "credits": 3.0
   },
   {
-    "code": "ASAM077B",
-    "title": "Tattoos:Aesthetics,Culture,Pasts",
+    "code": "ASAM077",
+    "title": "Tattoos in American Pop Culture",
     "campus": "pz",
     "credits": 3.0
   },
@@ -3313,6 +4177,18 @@
   },
   {
     "code": "ASAM086",
+    "title": "Social Documentation",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ASAM086",
+    "title": "Social Documentation/Asian Amer",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ASAM086",
     "title": "Social Documentation/Asian-Amer",
     "campus": "hmc",
     "credits": 3.0
@@ -3320,6 +4196,12 @@
   {
     "code": "ASAM088",
     "title": "China: Gender Cosmology & State",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ASAM088",
+    "title": "Thich Nhat Hanh",
     "campus": "pz",
     "credits": 3.0
   },
@@ -3333,6 +4215,12 @@
     "code": "ASAM090",
     "title": "Asian Amer+Multiracial Community",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ASAM090",
+    "title": "Community Studies",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -3372,6 +4260,12 @@
     "credits": 3.0
   },
   {
+    "code": "ASAM102",
+    "title": "Social Responsibility Praxis",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "ASAM103",
     "title": "Asian American Voices",
     "campus": "pz",
@@ -3384,14 +4278,20 @@
     "credits": 3.0
   },
   {
-    "code": "ASAM105",
-    "title": "Zines, Creativity, Community",
+    "code": "ASAM105B",
+    "title": "Zines In The Asian Diaspora",
     "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "ASAM105B",
-    "title": "Zines In The Asian Diaspora",
+    "title": "Zines in the Asian Diaspora",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ASAM105",
+    "title": "Zines, Creativity, Community",
     "campus": "pz",
     "credits": 3.0
   },
@@ -3421,6 +4321,12 @@
   },
   {
     "code": "ASAM111",
+    "title": "Pacific Islanders & Education",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ASAM111",
     "title": "Pacific Islanders and Education",
     "campus": "hmc",
     "credits": 3.0
@@ -3438,8 +4344,20 @@
     "credits": 3.0
   },
   {
+    "code": "ASAM115",
+    "title": "Theory and Methods",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "ASAM120",
     "title": "Critical Fil Am Studies",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ASAM120",
+    "title": "Sex Work in Asia / America",
     "campus": "pz",
     "credits": 3.0
   },
@@ -3451,8 +4369,20 @@
   },
   {
     "code": "ASAM125",
+    "title": "Asian American Hist: 1850-Presnt",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ASAM125",
     "title": "Intro Asian Amer Hist:1850-Pres",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ASAM125",
+    "title": "Intro to Asian American History",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -3476,6 +4406,12 @@
   {
     "code": "ASAM135",
     "title": "Race Empire Filipina/o America",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ASAM135",
+    "title": "Race Empire Filipinx America",
     "campus": "pz",
     "credits": 3.0
   },
@@ -3522,12 +4458,6 @@
     "credits": 3.0
   },
   {
-    "code": "ASAM179",
-    "title": "Spec Topics: Asian Amer Studies",
-    "campus": "hmc",
-    "credits": 3.0
-  },
-  {
     "code": "ASAM179A",
     "title": "Asian American Communities",
     "campus": "hmc",
@@ -3536,6 +4466,12 @@
   {
     "code": "ASAM179B",
     "title": "Asian Americans and the Law",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ASAM179C",
+    "title": "Queering Asian America",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -3553,6 +4489,12 @@
   },
   {
     "code": "ASAM179E",
+    "title": "Asian/Americans & Popular Cultre",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ASAM179E",
     "title": "Asian/Americans & PopularCulture",
     "campus": "hmc",
     "credits": 3.0
@@ -3560,6 +4502,12 @@
   {
     "code": "ASAM179F",
     "title": "Intro: Pacific Islander History",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ASAM179",
+    "title": "Spec Topics: Asian Amer Studies",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -3576,27 +4524,27 @@
     "credits": 3.0
   },
   {
-    "code": "ASAM189",
-    "title": "Globalization and Oceania",
-    "campus": "pz",
-    "credits": 3.0
-  },
-  {
     "code": "ASAM189A",
     "title": "Music in Asian America",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "ASAM190",
-    "title": "Senior Seminar",
-    "campus": "po",
+    "code": "ASAM189",
+    "title": "Globalization and Oceania",
+    "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "ASAM190A",
     "title": "Asian Amer Studies Senior Sem",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ASAM190A",
+    "title": "Senior Seminar",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -3618,9 +4566,21 @@
     "credits": 3.0
   },
   {
+    "code": "ASAM190",
+    "title": "Senior Seminar",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "ASAM191",
     "title": "Senior Thesis Asian Amer Studies",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ASAM191",
+    "title": "Senior Thesis:Asian American St",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -3636,12 +4596,6 @@
     "credits": 3.0
   },
   {
-    "code": "ASAM199",
-    "title": "Independent St: Asian Amer St",
-    "campus": "sc",
-    "credits": 3.0
-  },
-  {
     "code": "ASAM199DRPO",
     "title": "Asian Amer St: Directed Readings",
     "campus": "po",
@@ -3651,6 +4605,12 @@
     "code": "ASAM199IRPO",
     "title": "Asian American St: Indep Resrch",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ASAM199",
+    "title": "Independent St: Asian Amer St",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -3678,6 +4638,12 @@
     "credits": 3.0
   },
   {
+    "code": "ASIA191",
+    "title": "Senior Thesis: Asian Studies",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ASIA192",
     "title": "Senior Essay in Asian Studies",
     "campus": "po",
@@ -3687,12 +4653,6 @@
     "code": "ASIA198",
     "title": "Summer Reading & Research",
     "campus": "po",
-    "credits": 3.0
-  },
-  {
-    "code": "ASIA199",
-    "title": "Independent St: Asian Studies",
-    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -3708,6 +4668,12 @@
     "credits": 3.0
   },
   {
+    "code": "ASIA199",
+    "title": "Independent St: Asian Studies",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ASIA199RAPO",
     "title": "Asian St: Research Assistantship",
     "campus": "po",
@@ -3715,7 +4681,31 @@
   },
   {
     "code": "ASTR001",
+    "title": "Introduction to the Universe",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ASTR001",
+    "title": "Introductory Astronomy w/ Lab",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ASTR001",
     "title": "Introductory Astronomy w/Lab",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ASTR001",
+    "title": "Lab, Introductory Astronomy",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ASTR002",
+    "title": "Intro to Galax & Cosmology Lab",
     "campus": "po",
     "credits": 3.0
   },
@@ -3732,6 +4722,12 @@
     "credits": 3.0
   },
   {
+    "code": "ASTR003",
+    "title": "Life in the Universe Laboratory",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "ASTR006",
     "title": "Archeoastronomy/World Cosmology",
     "campus": "po",
@@ -3744,9 +4740,21 @@
     "credits": 3.0
   },
   {
+    "code": "ASTR009",
+    "title": "Lab, Cosmic Origins",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "ASTR021",
     "title": "Stars,Planets,Life: Astrobiology",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ASTR051",
+    "title": "Advanced Intr. Astronomy Lab",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -3775,14 +4783,32 @@
   },
   {
     "code": "ASTR101",
+    "title": "Lab, Observational Astrophysics",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ASTR101",
     "title": "Observational Astronomy",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ASTR101",
+    "title": "Techn in Observtnal Astrophysics",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ASTR120",
     "title": "Star Formation/Interstellar Med",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ASTR120",
+    "title": "Star Formatn & Interstellar Medm",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -3798,9 +4824,21 @@
     "credits": 3.0
   },
   {
+    "code": "ASTR122",
+    "title": "High-Energy Astrophysics",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "ASTR123",
     "title": "Stellar Structure & Evolution",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ASTR123",
+    "title": "Stellar Structure and Evolution",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -3828,12 +4866,6 @@
     "credits": 3.0
   },
   {
-    "code": "ASTR199",
-    "title": "Independent Study in Astronomy",
-    "campus": "sc",
-    "credits": 3.0
-  },
-  {
     "code": "ASTR199DRPO",
     "title": "Astronomy: Directed Readings",
     "campus": "po",
@@ -3843,6 +4875,12 @@
     "code": "ASTR199IRPO",
     "title": "Astronomy: Independent Research",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ASTR199",
+    "title": "Independent Study in Astronomy",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -3900,8 +4938,20 @@
     "credits": 3.0
   },
   {
+    "code": "BIOL002A",
+    "title": "Biology, Gender, & Society w/lab",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "BIOL002ALPO",
     "title": "Biology, Gender and Society Lab",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL002A",
+    "title": "Science, Power, & Identity w/Lab",
     "campus": "po",
     "credits": 3.0
   },
@@ -3915,6 +4965,12 @@
     "code": "BIOL039L",
     "title": "Analyses of Human Motor Skills",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL040",
+    "title": "Introductory Genetics Lab",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -4011,6 +5067,12 @@
     "code": "BIOL053",
     "title": "Public Health Biology and Ethics",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL054",
+    "title": "Biology Laboratory",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -4116,14 +5178,14 @@
     "credits": 3.0
   },
   {
-    "code": "BIOL081",
-    "title": "Current Issues in Biology",
+    "code": "BIOL081A",
+    "title": "Science and Pseudoscience",
     "campus": "hmc",
     "credits": 3.0
   },
   {
-    "code": "BIOL081A",
-    "title": "Science and Pseudoscience",
+    "code": "BIOL081",
+    "title": "Current Issues in Biology",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -4140,14 +5202,20 @@
     "credits": 3.0
   },
   {
-    "code": "BIOL083L",
-    "title": "Science,Management & Technology",
-    "campus": "sc",
+    "code": "BIOL082L",
+    "title": "Plant Biotechnology Greener Wrld",
+    "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "BIOL083LCJT",
     "title": "Sci,Mgmt,Tech: Neuropharmacology",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL083L",
+    "title": "Science,Management & Technology",
     "campus": "sc",
     "credits": 3.0
   },
@@ -4188,6 +5256,12 @@
     "credits": 3.0
   },
   {
+    "code": "BIOL103",
+    "title": "Invasion Biology",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "BIOL104",
     "title": "Conservation Biology",
     "campus": "po",
@@ -4200,8 +5274,20 @@
     "credits": 3.0
   },
   {
+    "code": "BIOL106",
+    "title": "Aquatic Ecology Lab",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "BIOL107",
     "title": "Avian Ecology",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL107",
+    "title": "Avian Ecology w/Lab",
     "campus": "po",
     "credits": 3.0
   },
@@ -4213,8 +5299,32 @@
   },
   {
     "code": "BIOL109",
+    "title": "Biological & Environmental Sci",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL109",
     "title": "Evolutionary Biology",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL109",
+    "title": "Lab, Molecular Evolution",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL109",
+    "title": "Molecular Evol:The Tree of Life",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL110",
+    "title": "Biochemistry for Pre-Health",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -4232,6 +5342,18 @@
   {
     "code": "BIOL112",
     "title": "Advanced Animal Ecology",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL112",
+    "title": "Advanced Animal Ecology w/Lab",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL112",
+    "title": "Lab, Advanced Animal Ecology",
     "campus": "po",
     "credits": 3.0
   },
@@ -4254,6 +5376,12 @@
     "credits": 3.0
   },
   {
+    "code": "BIOL116",
+    "title": "Ecology/Evolution of Plants Lab",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "BIOL119",
     "title": "Advanced Mathematical Biology",
     "campus": "hmc",
@@ -4267,13 +5395,19 @@
   },
   {
     "code": "BIOL121",
-    "title": "Marine Ecology",
-    "campus": "hmc",
+    "title": "Insect Ecology & Behavior w/Lab",
+    "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "BIOL122",
-    "title": "Cell and Developmental Biology",
+    "code": "BIOL121",
+    "title": "Lab, Insect Ecology & Behavior",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL121",
+    "title": "Marine Ecology",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -4290,8 +5424,20 @@
     "credits": 3.0
   },
   {
+    "code": "BIOL122",
+    "title": "Cell and Developmental Biology",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "BIOL125",
     "title": "Animal Behavior with Laboratory",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL125",
+    "title": "Lab, Animal Behavior",
     "campus": "po",
     "credits": 3.0
   },
@@ -4332,8 +5478,8 @@
     "credits": 3.0
   },
   {
-    "code": "BIOL132",
-    "title": "Vertebrate Biology with Lab",
+    "code": "BIOL131",
+    "title": "Lab, Invertebrate Biology",
     "campus": "po",
     "credits": 3.0
   },
@@ -4341,6 +5487,18 @@
     "code": "BIOL132L",
     "title": "Comparative Physiology",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL132",
+    "title": "Lab, Vertebrate Biology",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL132",
+    "title": "Vertebrate Biology with Lab",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -4369,6 +5527,12 @@
   },
   {
     "code": "BIOL138L",
+    "title": "Appl Ecol + Conservation Lab",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL138L",
     "title": "Appl Ecol + Conservation w/Lab",
     "campus": "sc",
     "credits": 3.0
@@ -4377,6 +5541,18 @@
     "code": "BIOL139",
     "title": "Applied Ecology & Conservation",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL140",
+    "title": "Animal Physiology w/Laboratory",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL140",
+    "title": "Lab, Animal Physiology",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -4411,8 +5587,20 @@
   },
   {
     "code": "BIOL144",
+    "title": "Comparative Endocrinology w/Lab",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL144",
     "title": "Drugs and Molecular Medicine",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL144",
+    "title": "Lab, Comparative Endocrinology",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -4434,6 +5622,12 @@
     "credits": 3.0
   },
   {
+    "code": "BIOL147",
+    "title": "Lab, Biochem: Metabolomics & Reg",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "BIOL148L",
     "title": "Neuroscience I:Cell, Molecular",
     "campus": "sc",
@@ -4452,12 +5646,6 @@
     "credits": 3.0
   },
   {
-    "code": "BIOL150",
-    "title": "Biomechanics",
-    "campus": "sc",
-    "credits": 3.0
-  },
-  {
     "code": "BIOL150ALKS",
     "title": "Anat & Biomech:Limbs & Movement",
     "campus": "sc",
@@ -4470,8 +5658,20 @@
     "credits": 3.0
   },
   {
+    "code": "BIOL150",
+    "title": "Biomechanics",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "BIOL151L",
     "title": "Developmental Biology",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL154",
+    "title": "Animal Behavior",
     "campus": "sc",
     "credits": 3.0
   },
@@ -4525,8 +5725,26 @@
   },
   {
     "code": "BIOL160",
+    "title": "Immunology",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL160",
     "title": "Molecular Immunology",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL161",
+    "title": "Immunology Laboratory",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL161",
+    "title": "Neuroendocrinology",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -4537,8 +5755,8 @@
   },
   {
     "code": "BIOL162",
-    "title": "Research Problems in Biology",
-    "campus": "hmc",
+    "title": "Genetic Analysis",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -4548,8 +5766,20 @@
     "credits": 3.0
   },
   {
+    "code": "BIOL162",
+    "title": "Research Problems in Biology",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "BIOL163",
     "title": "Advanced Cell Biology with Lab",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL163",
+    "title": "Cell Biology Laboratory",
     "campus": "po",
     "credits": 3.0
   },
@@ -4566,8 +5796,14 @@
     "credits": 3.0
   },
   {
-    "code": "BIOL165",
-    "title": "Adv Topics: Environmental Biol",
+    "code": "BIOL164",
+    "title": "Lab, Genetic Reg in Eukaryotes",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL164",
+    "title": "Virology",
     "campus": "sc",
     "credits": 3.0
   },
@@ -4584,9 +5820,51 @@
     "credits": 3.0
   },
   {
+    "code": "BIOL165",
+    "title": "Adv Topics: Environmental Biol",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL165",
+    "title": "Genetic Regulation Seminar",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL166",
+    "title": "Animal Physiological Ecology",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "BIOL166",
     "title": "Cell Biology and Genetics Lab",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL166",
+    "title": "Lab, Plant Physiology",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL166",
+    "title": "Plant Physiology With Laboratory",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL167",
+    "title": "Lab, Microbial Genetics",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL167",
+    "title": "Microbial Genetics",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -4620,6 +5898,12 @@
     "credits": 3.0
   },
   {
+    "code": "BIOL169",
+    "title": "Lab, Developmental Biology",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "BIOL170",
     "title": "Genomics & Transcriptomics w/Lab",
     "campus": "po",
@@ -4638,6 +5922,12 @@
     "credits": 3.0
   },
   {
+    "code": "BIOL171",
+    "title": "Biology of Cancer",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "BIOL172",
     "title": "Research Methods Bioinformatics",
     "campus": "po",
@@ -4650,9 +5940,21 @@
     "credits": 3.0
   },
   {
+    "code": "BIOL173",
+    "title": "Genomics & Bioinformatics w/Lab",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "BIOL173L",
     "title": "Molecular Biology Seminar w/Lab",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL173",
+    "title": "Lab, Genomics and Bioinformatics",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -4665,6 +5967,24 @@
     "code": "BIOL174L",
     "title": "Intro Biological Research Stat",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL174",
+    "title": "Lab, Prgrm for Life Sciences",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL174",
+    "title": "Programming for Biologists",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL174",
+    "title": "Progrm for Life Sciences w/Lab",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -4699,6 +6019,12 @@
   },
   {
     "code": "BIOL181",
+    "title": "Fire Ecology in So CA w/ Lab",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL181",
     "title": "Neurological Disorders",
     "campus": "sc",
     "credits": 3.0
@@ -4710,8 +6036,20 @@
     "credits": 3.0
   },
   {
+    "code": "BIOL182",
+    "title": "Chemistry in Living Systems",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "BIOL182L",
     "title": "Applied Phylogenetics",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL183",
+    "title": "Nutritional Biology",
     "campus": "sc",
     "credits": 3.0
   },
@@ -4734,8 +6072,8 @@
     "credits": 3.0
   },
   {
-    "code": "BIOL185",
-    "title": "Special Topics in Biology",
+    "code": "BIOL184",
+    "title": "Methods in Biochemistry",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -4752,13 +6090,19 @@
     "credits": 3.0
   },
   {
+    "code": "BIOL185",
+    "title": "Biochemical Physiology",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "BIOL185L",
     "title": "Biochemical Physiology with Lab",
     "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "BIOL186",
+    "code": "BIOL185",
     "title": "Special Topics in Biology",
     "campus": "hmc",
     "credits": 3.0
@@ -4788,8 +6132,8 @@
     "credits": 3.0
   },
   {
-    "code": "BIOL187",
-    "title": "HIV/AIDS: Sci, Society & Service",
+    "code": "BIOL186",
+    "title": "Special Topics in Biology",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -4818,6 +6162,12 @@
     "credits": 3.0
   },
   {
+    "code": "BIOL187",
+    "title": "HIV/AIDS: Sci, Society & Service",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "BIOL187M",
     "title": "Special Topics: UAV's",
     "campus": "sc",
@@ -4826,6 +6176,12 @@
   {
     "code": "BIOL187P",
     "title": "Special Topics: Herpetology",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL187",
+    "title": "Special Topics in Biology",
     "campus": "sc",
     "credits": 3.0
   },
@@ -4839,12 +6195,6 @@
     "code": "BIOL188L",
     "title": "Sr Thesis Rsrch Project in Biol",
     "campus": "sc",
-    "credits": 3.0
-  },
-  {
-    "code": "BIOL189",
-    "title": "Topics in Biochem/Molecular Biol",
-    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -4873,6 +6223,12 @@
   },
   {
     "code": "BIOL189L",
+    "title": "Emerging Infectious Diseases",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL189L",
     "title": "Sr Thes Summer Rsrch Proj in Bio",
     "campus": "sc",
     "credits": 3.0
@@ -4884,14 +6240,14 @@
     "credits": 3.0
   },
   {
-    "code": "BIOL189N",
-    "title": "Microbiology with Laboratory",
+    "code": "BIOL189NLPO",
+    "title": "Lab, Microbiology",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "BIOL189NLPO",
-    "title": "Lab, Microbiology",
+    "code": "BIOL189N",
+    "title": "Microbiology with Laboratory",
     "campus": "po",
     "credits": 3.0
   },
@@ -4920,6 +6276,18 @@
     "credits": 3.0
   },
   {
+    "code": "BIOL189",
+    "title": "Topics in Biochem/Molecular Biol",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL189",
+    "title": "Topics in Cell Chemistry & Cell",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "BIOL189X",
     "title": "Molecular Ecology",
     "campus": "po",
@@ -4932,15 +6300,15 @@
     "credits": 3.0
   },
   {
-    "code": "BIOL190",
-    "title": "Biology Senior Seminar",
-    "campus": "po",
-    "credits": 3.0
-  },
-  {
     "code": "BIOL190B",
     "title": "Biomechanics",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL190",
+    "title": "Biology Senior Seminar",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -4956,6 +6324,18 @@
     "credits": 3.0
   },
   {
+    "code": "BIOL191",
+    "title": "One-Semester Thesis in Biology",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL191",
+    "title": "Senior Grant Proposal",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "BIOL192",
     "title": "Biology Colloquium",
     "campus": "hmc",
@@ -4963,12 +6343,6 @@
   },
   {
     "code": "BIOL193",
-    "title": "Senior Thesis Research: Biology",
-    "campus": "hmc",
-    "credits": 3.0
-  },
-  {
-    "code": "BIOL194",
     "title": "Senior Thesis Research: Biology",
     "campus": "hmc",
     "credits": 3.0
@@ -4983,6 +6357,12 @@
     "code": "BIOL194B",
     "title": "Experimental Sen Thesis-2nd Sem.",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL194",
+    "title": "Senior Thesis Research: Biology",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -5016,9 +6396,15 @@
     "credits": 3.0
   },
   {
-    "code": "BIOL199",
-    "title": "Independent Study in Biology",
-    "campus": "cgu",
+    "code": "BIOL198",
+    "title": "Independent Internship",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL198",
+    "title": "Summer Reading & Research",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -5034,6 +6420,12 @@
     "credits": 3.0
   },
   {
+    "code": "BIOL199",
+    "title": "Independent Study in Biology",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
     "code": "BIOL199L",
     "title": "Independent Study in Biology",
     "campus": "sc",
@@ -5043,6 +6435,12 @@
     "code": "BIOL199RAPO",
     "title": "Biology: Research Assistantship",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOL199",
+    "title": "Senior Thesis",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -5076,14 +6474,14 @@
     "credits": 3.0
   },
   {
-    "code": "BLCK195",
-    "title": "Spec Top: Spirituals to Stomp\"\"",
+    "code": "BLCK195E",
+    "title": "Haitian Revolution",
     "campus": "pz",
     "credits": 3.0
   },
   {
-    "code": "BLCK195E",
-    "title": "Haitian Revolution",
+    "code": "BLCK195",
+    "title": "Spec Top: Spirituals to Stomp\"\"",
     "campus": "pz",
     "credits": 3.0
   },
@@ -5425,8 +6823,14 @@
   },
   {
     "code": "CHEM051",
-    "title": "Physical Chem: Thermody/Kinetics",
-    "campus": "hmc",
+    "title": "Gen Chemistry w/Lab Accelerated",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CHEM051LLKS",
+    "title": "Topics in Forensic Science",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -5436,9 +6840,15 @@
     "credits": 3.0
   },
   {
-    "code": "CHEM051LLKS",
-    "title": "Topics in Forensic Science",
-    "campus": "sc",
+    "code": "CHEM051",
+    "title": "Lab, General Chemistry (Accel)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CHEM051",
+    "title": "Physical Chem: Thermody/Kinetics",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -5467,7 +6877,19 @@
   },
   {
     "code": "CHEM056",
+    "title": "Carbon Compounds",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CHEM056",
     "title": "Organic Chemistry I",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CHEM058",
+    "title": "Carbon Compounds Laboratory",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -5503,6 +6925,12 @@
   },
   {
     "code": "CHEM081L",
+    "title": "Molec Gastron:Chem of Food&Cook",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "CHEM081L",
     "title": "Sci/Bus of Medicinal Chemistry",
     "campus": "sc",
     "credits": 3.0
@@ -5527,6 +6955,12 @@
   },
   {
     "code": "CHEM105",
+    "title": "Organic Chemistry",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CHEM105",
     "title": "Organic Chemistry II",
     "campus": "hmc",
     "credits": 3.0
@@ -5544,25 +6978,13 @@
     "credits": 3.0
   },
   {
-    "code": "CHEM110",
-    "title": "Inorganic Chemistry Laboratory",
-    "campus": "hmc",
-    "credits": 3.0
-  },
-  {
-    "code": "CHEM110A",
-    "title": "Organic Chemistry w/Laboratory",
-    "campus": "po",
-    "credits": 3.0
-  },
-  {
     "code": "CHEM110ALPO",
     "title": "Lab, Organic Chemistry",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "CHEM110B",
+    "code": "CHEM110A",
     "title": "Organic Chemistry w/Laboratory",
     "campus": "po",
     "credits": 3.0
@@ -5574,9 +6996,33 @@
     "credits": 3.0
   },
   {
+    "code": "CHEM110B",
+    "title": "Organic Chemistry w/Laboratory",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CHEM110",
+    "title": "Inorganic Chemistry Laboratory",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "CHEM111",
     "title": "Organic Chemistry II Laboratory",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CHEM111",
+    "title": "Organic Chemistry Laboratory",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CHEM112",
+    "title": "Analysis Scientific Literature",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -5598,14 +7044,20 @@
     "credits": 3.0
   },
   {
-    "code": "CHEM116L",
-    "title": "Organic Chemistry",
-    "campus": "sc",
+    "code": "CHEM115",
+    "title": "Lab, Biochemistry",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "CHEM116LLKS",
     "title": "Organic Chem Lab",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "CHEM116L",
+    "title": "Organic Chemistry",
     "campus": "sc",
     "credits": 3.0
   },
@@ -5616,14 +7068,14 @@
     "credits": 3.0
   },
   {
-    "code": "CHEM117L",
-    "title": "Organic Chemistry",
+    "code": "CHEM117LLKS",
+    "title": "Organic Chem Lab",
     "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "CHEM117LLKS",
-    "title": "Organic Chem Lab",
+    "code": "CHEM117L",
+    "title": "Organic Chemistry",
     "campus": "sc",
     "credits": 3.0
   },
@@ -5655,6 +7107,12 @@
     "code": "CHEM122",
     "title": "Materials Chemistry Laboratory",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CHEM122",
+    "title": "Principles of Physical Chemistry",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -5724,6 +7182,18 @@
     "credits": 3.0
   },
   {
+    "code": "CHEM147",
+    "title": "Inorganic Chemistry with Lab",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CHEM147",
+    "title": "Lab, Inorganic Chemistry",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "CHEM150",
     "title": "Research in Chemistry",
     "campus": "hmc",
@@ -5731,7 +7201,19 @@
   },
   {
     "code": "CHEM151",
+    "title": "Research Problems in Chemistry",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CHEM151",
     "title": "Senior Thesis Research:Chemistry",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CHEM152",
+    "title": "Research Problems in Chemistry",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -5754,14 +7236,14 @@
     "credits": 3.0
   },
   {
-    "code": "CHEM158B",
-    "title": "Physical Chemistry w/ Laboratory",
+    "code": "CHEM158BLPO",
+    "title": "Laboratory, Physical Chem",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "CHEM158BLPO",
-    "title": "Laboratory, Physical Chem",
+    "code": "CHEM158B",
+    "title": "Physical Chemistry w/ Laboratory",
     "campus": "po",
     "credits": 3.0
   },
@@ -5769,6 +7251,24 @@
     "code": "CHEM161",
     "title": "AdvPhysChem:Classicl/Stat Thermo",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CHEM161",
+    "title": "Advanced Analytical Chemistry",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CHEM161",
+    "title": "Lab, Advanced Analytical",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CHEM162",
+    "title": "Lab, Adv Physical Chem",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -5781,6 +7281,12 @@
     "code": "CHEM163",
     "title": "Advanced Physical Chem - Group",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CHEM164",
+    "title": "Computational Chemistry",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -5804,12 +7310,6 @@
   {
     "code": "CHEM167",
     "title": "Biophysical Chemistry",
-    "campus": "hmc",
-    "credits": 3.0
-  },
-  {
-    "code": "CHEM168",
-    "title": "Lasers in Chemistry",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -5844,6 +7344,12 @@
     "credits": 3.0
   },
   {
+    "code": "CHEM168",
+    "title": "Lasers in Chemistry",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "CHEM170",
     "title": "Computer Programming for Chemist",
     "campus": "po",
@@ -5853,6 +7359,18 @@
     "code": "CHEM171",
     "title": "Adv Org Chem: Organic Synthesis",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CHEM171",
+    "title": "Adv. Org. Chem.: Synthesis",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CHEM171",
+    "title": "Organic Synthesis",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -5899,6 +7417,12 @@
   },
   {
     "code": "CHEM180",
+    "title": "Advanced Biochemistry",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CHEM180",
     "title": "Applied Molecular Evolution",
     "campus": "sc",
     "credits": 3.0
@@ -5916,8 +7440,20 @@
     "credits": 3.0
   },
   {
+    "code": "CHEM182",
+    "title": "Chemistry in Living Systems",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "CHEM184",
     "title": "Biochemistry Laboratory",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CHEM184",
+    "title": "Methods in Biochemistry",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -5946,12 +7482,6 @@
     "credits": 3.0
   },
   {
-    "code": "CHEM189",
-    "title": "Topics in Biochem/Molecular Biol",
-    "campus": "hmc",
-    "credits": 3.0
-  },
-  {
     "code": "CHEM189A",
     "title": "Atmosphere and Ocean Chemistry",
     "campus": "po",
@@ -5961,6 +7491,12 @@
     "code": "CHEM189L",
     "title": "Sr Ths Summer Rsrch Proj in Chem",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "CHEM189",
+    "title": "Topics in Biochem/Molecular Biol",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -5976,26 +7512,26 @@
     "credits": 3.0
   },
   {
-    "code": "CHEM191",
-    "title": "One-Semester Thesis in Chemistry",
-    "campus": "sc",
-    "credits": 3.0
-  },
-  {
     "code": "CHEM191B",
     "title": "Senior Thesis",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "CHEM192",
-    "title": "Mater Sci of Energy Conv & Stor",
-    "campus": "hmc",
+    "code": "CHEM191",
+    "title": "One-Semester Thesis in Chemistry",
+    "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "CHEM193",
-    "title": "Special Topics in Chemistry",
+    "code": "CHEM191",
+    "title": "Senior Literature Thesis",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CHEM192",
+    "title": "Mater Sci of Energy Conv & Stor",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -6048,15 +7584,33 @@
     "credits": 3.0
   },
   {
+    "code": "CHEM193",
+    "title": "Special Topics in Chemistry",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "CHEM194",
     "title": "Chemistry of Modern Materials",
     "campus": "hmc",
     "credits": 3.0
   },
   {
+    "code": "CHEM194",
+    "title": "Senior Experimental Thesis",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "CHEM197",
     "title": "Readings in Chemistry",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CHEM198",
+    "title": "Independent Internship",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -6084,6 +7638,12 @@
     "credits": 3.0
   },
   {
+    "code": "CHEM199",
+    "title": "Independent Study in Chemistry",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "CHEM199L",
     "title": "Independent Study in Chemistry",
     "campus": "sc",
@@ -6103,8 +7663,20 @@
   },
   {
     "code": "CHIN001A",
+    "title": "Elementary Chinese",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CHIN001A",
     "title": "Elementary Chinese 1",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CHIN001B",
+    "title": "Elementary Chinese",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -6253,6 +7825,12 @@
   },
   {
     "code": "CHLT060",
+    "title": "Women in the The Third World",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "CHLT060",
     "title": "Women in the Third World",
     "campus": "pz",
     "credits": 3.0
@@ -6366,6 +7944,12 @@
     "credits": 3.0
   },
   {
+    "code": "CHLT153",
+    "title": "Rural and Urban Social Movements",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "CHLT154",
     "title": "Latinas in the Garment Industry",
     "campus": "pz",
@@ -6462,6 +8046,18 @@
     "credits": 3.0
   },
   {
+    "code": "CHST015",
+    "title": "Intro to Chicanx Latinx Studies",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "CHST015",
+    "title": "Intro to Chicanx-Latinx Studies",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "CHST028",
     "title": "Intro to Central Amer Studies",
     "campus": "po",
@@ -6480,6 +8076,12 @@
     "credits": 3.0
   },
   {
+    "code": "CHST064",
+    "title": "Chicanx Music Experience",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "CHST066",
     "title": "Fandango as a De-Colonial Tool",
     "campus": "sc",
@@ -6492,8 +8094,20 @@
     "credits": 3.0
   },
   {
+    "code": "CHST067",
+    "title": "Contemp Chicanx Art/Antecedents",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "CHST074",
     "title": "Women Who Rock",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "CHST077",
+    "title": "Chicana-Latina,Gndr,Pop Culture",
     "campus": "sc",
     "credits": 3.0
   },
@@ -6534,8 +8148,20 @@
     "credits": 3.0
   },
   {
+    "code": "CHST125",
+    "title": "Latinxs in the 20th Century",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "CHST126A",
     "title": "Chicano/a Movement Literature",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "CHST126A",
+    "title": "Chicanx Movement Literature",
     "campus": "sc",
     "credits": 3.0
   },
@@ -6543,6 +8169,18 @@
     "code": "CHST126B",
     "title": "Contemporary Chicana/o Lit",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "CHST126B",
+    "title": "Contemporary Chicanx Literature",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "CHST128",
+    "title": "Latinx Citizenship",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -6564,8 +8202,20 @@
     "credits": 3.0
   },
   {
+    "code": "CHST132",
+    "title": "Immigrant Youth Activism (CP)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "CHST136",
     "title": "Chicano/a Latino/a Politics",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CHST136",
+    "title": "Chicanx/Latinx Social Movements",
     "campus": "po",
     "credits": 3.0
   },
@@ -6582,8 +8232,20 @@
     "credits": 3.0
   },
   {
+    "code": "CHST184D",
+    "title": "Chicanx Short Fiction",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "CHST185A",
     "title": "Decolonial Love US Latina/o Lit",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "CHST185A",
+    "title": "Decolonial Love US Latinx Lit",
     "campus": "sc",
     "credits": 3.0
   },
@@ -6624,12 +8286,6 @@
     "credits": 3.0
   },
   {
-    "code": "CHST199",
-    "title": "Senior Thesis",
-    "campus": "pz",
-    "credits": 3.0
-  },
-  {
     "code": "CHST199DRPO",
     "title": "Chicano St: Directed Readings",
     "campus": "po",
@@ -6651,6 +8307,12 @@
     "code": "CHST199RAPO",
     "title": "Chicano St: Research Assistantsh",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CHST199",
+    "title": "Senior Thesis",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -6685,6 +8347,12 @@
   },
   {
     "code": "CLAS010",
+    "title": "Epic Heroes & Form in Pop Cult",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "CLAS010",
     "title": "The Epic Tradition",
     "campus": "po",
     "credits": 3.0
@@ -6693,6 +8361,18 @@
     "code": "CLAS012",
     "title": "Greek Tragedy",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CLAS012",
+    "title": "Greek Tragedy in Modern World",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "CLAS014",
+    "title": "Ancient Comedy",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -6720,9 +8400,27 @@
     "credits": 3.0
   },
   {
+    "code": "CLAS018",
+    "title": "The Ancient Novel and Romance",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "CLAS019",
+    "title": "Classical Myth in Film",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "CLAS019",
     "title": "The Ancient World in Film",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "CLAS020",
+    "title": "Fantastic Archaeology",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -6739,8 +8437,20 @@
   },
   {
     "code": "CLAS032",
+    "title": "Advanced Introductory Latin",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "CLAS032",
     "title": "Introductory Latin Accelerated",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CLAS032",
+    "title": "Introductory/Intermediate Latin",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -6756,12 +8466,6 @@
     "credits": 3.0
   },
   {
-    "code": "CLAS052",
-    "title": "Intro Classical Greek Accel",
-    "campus": "po",
-    "credits": 3.0
-  },
-  {
     "code": "CLAS052A",
     "title": "Elementary Classical Hebrew",
     "campus": "po",
@@ -6770,6 +8474,12 @@
   {
     "code": "CLAS052B",
     "title": "Elementary Classical Hebrew",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CLAS052",
+    "title": "Intro Classical Greek Accel",
     "campus": "po",
     "credits": 3.0
   },
@@ -6811,8 +8521,20 @@
   },
   {
     "code": "CLAS101A",
+    "title": "Intermediate Classical Greek",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "CLAS101A",
     "title": "Intermediate Greek",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CLAS101B",
+    "title": "Intermediate Classical Greek",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -6865,7 +8587,25 @@
   },
   {
     "code": "CLAS115",
+    "title": "Antiquity and the East",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "CLAS115",
     "title": "Politics of Persuasion in Athens",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CLAS116A",
+    "title": "Out of The Cave",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CLAS116A",
+    "title": "Philosophy of Education",
     "campus": "po",
     "credits": 3.0
   },
@@ -6873,12 +8613,6 @@
     "code": "CLAS116",
     "title": "Out of the Cave",
     "campus": "pz",
-    "credits": 3.0
-  },
-  {
-    "code": "CLAS116A",
-    "title": "Philosophy of Education",
-    "campus": "po",
     "credits": 3.0
   },
   {
@@ -6925,19 +8659,31 @@
   },
   {
     "code": "CLAS145",
-    "title": "Archaeology Seminar",
-    "campus": "pz",
+    "title": "Ancient Political Thought",
+    "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "CLAS150",
-    "title": "Special Topics Seminar",
+    "code": "CLAS145",
+    "title": "Archaeology Seminar",
     "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "CLAS150BEPZ",
     "title": "The Roman Empire in the East",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "CLAS150",
+    "title": "Spec Top in Ancient Studies",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "CLAS150",
+    "title": "Special Topics Seminar",
     "campus": "pz",
     "credits": 3.0
   },
@@ -7008,9 +8754,39 @@
     "credits": 3.0
   },
   {
+    "code": "CLAS190",
+    "title": "Senior Seminar in Classics",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CLAS190",
+    "title": "Senior Seminar: Classics",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "CLAS190",
+    "title": "Sr Seminar: Ancient St/Classics",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "CLAS191",
+    "title": "Senior Thesis",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "CLAS191",
     "title": "Senior Thesis in Classics",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CLAS191",
+    "title": "Sr Thesis: Ancient St/Classics",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -7032,12 +8808,6 @@
     "credits": 3.0
   },
   {
-    "code": "CLAS199",
-    "title": "Independent Study: Classics",
-    "campus": "sc",
-    "credits": 3.0
-  },
-  {
     "code": "CLAS199DRPO",
     "title": "Classics: Directed Readings",
     "campus": "po",
@@ -7047,6 +8817,12 @@
     "code": "CLAS199IRPO",
     "title": "Classics: Independent Research",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CLAS199",
+    "title": "Independent Study: Classics",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -7176,14 +8952,38 @@
     "credits": 3.0
   },
   {
+    "code": "CMC199",
+    "title": "Off Campus Study",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CMC",
+    "title": "CMC Ethics Sequence Course",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "CMC",
     "title": "CMC Level-II Econ Elective",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "CMC199",
-    "title": "Off Campus Study",
+    "code": "CMC",
+    "title": "Credit for Military Service",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CMC",
+    "title": "Middle Eastern Studies Elective",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CMC",
+    "title": "Russian Studies Elective",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -7236,14 +9036,14 @@
     "credits": 3.0
   },
   {
-    "code": "CREA010",
-    "title": "Introduction to Creative Studies",
+    "code": "CREA010A",
+    "title": "Survey of British Literature A",
     "campus": "pz",
     "credits": 3.0
   },
   {
-    "code": "CREA010A",
-    "title": "Survey of British Literature A",
+    "code": "CREA010",
+    "title": "Introduction to Creative Studies",
     "campus": "pz",
     "credits": 3.0
   },
@@ -7273,6 +9073,18 @@
   },
   {
     "code": "CREA018",
+    "title": "History of Creative Studies",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "CREA018",
+    "title": "History of the Creative Process",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "CREA018",
     "title": "Introduction to Creative Studies",
     "campus": "pz",
     "credits": 3.0
@@ -7280,6 +9092,12 @@
   {
     "code": "CREA025",
     "title": "World in a Nutshell",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "CREA025",
+    "title": "World in a Nutshell:Short Storie",
     "campus": "pz",
     "credits": 3.0
   },
@@ -7346,6 +9164,12 @@
   {
     "code": "CREA102",
     "title": "Art, Aesthetic & Resistance",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "CREA102",
+    "title": "Museums and Material Culture",
     "campus": "pz",
     "credits": 3.0
   },
@@ -7446,14 +9270,14 @@
     "credits": 3.0
   },
   {
-    "code": "CREA193",
-    "title": "Magicians and Moderns",
+    "code": "CREA193A",
+    "title": "Fictions of James Joyce",
     "campus": "pz",
     "credits": 3.0
   },
   {
-    "code": "CREA193A",
-    "title": "Fictions of James Joyce",
+    "code": "CREA193",
+    "title": "Magicians and Moderns",
     "campus": "pz",
     "credits": 3.0
   },
@@ -7470,14 +9294,14 @@
     "credits": 3.0
   },
   {
-    "code": "CSCI005",
-    "title": "Introduction to Computer Science",
+    "code": "CSCI005GRHM",
+    "title": "Intro to Biology & Computer Sci",
     "campus": "hmc",
     "credits": 3.0
   },
   {
-    "code": "CSCI005GRHM",
-    "title": "Intro to Biology & Computer Sci",
+    "code": "CSCI005",
+    "title": "Introduction to Computer Science",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -7502,6 +9326,12 @@
   {
     "code": "CSCI030",
     "title": "Computation & Cognition w/Lab",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI030",
+    "title": "Lab, Computation and Cognition",
     "campus": "po",
     "credits": 3.0
   },
@@ -7548,12 +9378,6 @@
     "credits": 3.0
   },
   {
-    "code": "CSCI049",
-    "title": "Special Topics in Computer Sci",
-    "campus": "hmc",
-    "credits": 3.0
-  },
-  {
     "code": "CSCI049A",
     "title": "Computational Creativity",
     "campus": "hmc",
@@ -7572,9 +9396,9 @@
     "credits": 3.0
   },
   {
-    "code": "CSCI051",
-    "title": "Introduction to Computer Science",
-    "campus": "cmc",
+    "code": "CSCI049",
+    "title": "Special Topics in Computer Sci",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -7591,6 +9415,12 @@
   },
   {
     "code": "CSCI051G",
+    "title": "Intro to CS in Grace w/Lab",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI051G",
     "title": "Introduction to CS in Grace",
     "campus": "po",
     "credits": 3.0
@@ -7599,6 +9429,18 @@
     "code": "CSCI051GLPO",
     "title": "Lab, Intro to Comp Sci-Grace",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI051",
+    "title": "Intro to Computer Science w/Lab",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI051",
+    "title": "Introduction to Computer Science",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -7614,9 +9456,21 @@
     "credits": 3.0
   },
   {
+    "code": "CSCI051",
+    "title": "Lab, Intro to Computer Science",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "CSCI051P",
     "title": "Intro to CS in Python w/Lab",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI051P",
+    "title": "Introduction to CS in Python",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -7634,6 +9488,12 @@
   {
     "code": "CSCI054",
     "title": "Discrete Math and Func. Prog.",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI055",
+    "title": "Discrete Mathematics",
     "campus": "po",
     "credits": 3.0
   },
@@ -7662,6 +9522,12 @@
     "credits": 3.0
   },
   {
+    "code": "CSCI062",
+    "title": "Data Structures/Adv Program Lab",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "CSCI070",
     "title": "Data Structures/Prgm Development",
     "campus": "hmc",
@@ -7682,6 +9548,12 @@
   {
     "code": "CSCI078",
     "title": "Numerical Methods",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI081",
+    "title": "Computability & Logic",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -7710,6 +9582,12 @@
     "credits": 3.0
   },
   {
+    "code": "CSCI105",
+    "title": "Computer Systems, Lab",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "CSCI105L",
     "title": "Computer Systems Lab",
     "campus": "hmc",
@@ -7734,12 +9612,6 @@
     "credits": 3.0
   },
   {
-    "code": "CSCI124",
-    "title": "Interaction Design",
-    "campus": "hmc",
-    "credits": 3.0
-  },
-  {
     "code": "CSCI124A",
     "title": "Basics of User Interface Design",
     "campus": "hmc",
@@ -7749,6 +9621,18 @@
     "code": "CSCI124B",
     "title": "Non-Trad User Interface Design",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI124",
+    "title": "Interaction Design",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI124",
+    "title": "User Interfaces and Experience",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -7771,6 +9655,12 @@
   },
   {
     "code": "CSCI133",
+    "title": "Database Systems",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI133",
     "title": "Databases",
     "campus": "hmc",
     "credits": 3.0
@@ -7779,6 +9669,12 @@
     "code": "CSCI134",
     "title": "Operating Systems",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI134",
+    "title": "Operating Systems Principles",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -7791,6 +9687,12 @@
     "code": "CSCI136",
     "title": "Advanced Computer Architecture",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI136",
+    "title": "Computer Architecture",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -7827,6 +9729,12 @@
     "code": "CSCI145",
     "title": "Advanced Topics in Algorithms",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI145",
+    "title": "Data Mining",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -7891,14 +9799,20 @@
   },
   {
     "code": "CSCI160",
+    "title": "Applied Machine Learning",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI160",
     "title": "Information Retrieval",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "CSCI181",
-    "title": "Computer Science Seminar",
-    "campus": "hmc",
+    "code": "CSCI181A",
+    "title": "Seminar on Information Security",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -7920,6 +9834,18 @@
     "credits": 3.0
   },
   {
+    "code": "CSCI181",
+    "title": "Computer Science Seminar",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI181D",
+    "title": "Architecture Aware Algorithms",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "CSCI181D",
     "title": "Computational Complexity",
     "campus": "hmc",
@@ -7933,6 +9859,12 @@
   },
   {
     "code": "CSCI181F",
+    "title": "Seminar on Big Software",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI181F",
     "title": "Verification-Centric Softw Engrg",
     "campus": "hmc",
     "credits": 3.0
@@ -7941,6 +9873,18 @@
     "code": "CSCI181G",
     "title": "Concurrency in Computation",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI181G",
+    "title": "Seminar Social Network Analysis",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI181H",
+    "title": "Mobile Software Development",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -7962,9 +9906,21 @@
     "credits": 3.0
   },
   {
+    "code": "CSCI181J",
+    "title": "Intro to Software Engineering",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "CSCI181K",
     "title": "Great Papers in CS & Softw Engrg",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI181K",
+    "title": "Social Media Analysis",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -7975,14 +9931,44 @@
   },
   {
     "code": "CSCI181M",
+    "title": "Computational Photography",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI181M",
     "title": "Robotics Lab",
     "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "CSCI181N",
+    "title": "Advanced Functional Programming",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI181N",
     "title": "Computer Security",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI181N",
+    "title": "Software Foundations",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI181N",
+    "title": "Software Verification",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI181O",
+    "title": "Computational Semantics",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -7993,8 +9979,20 @@
   },
   {
     "code": "CSCI181P",
+    "title": "Image Processing",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI181P",
     "title": "Machine Learning, Info, & Search",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI181Q",
+    "title": "Graph Algorithm and Application",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -8010,9 +10008,27 @@
     "credits": 3.0
   },
   {
+    "code": "CSCI181R",
+    "title": "Network Analysis and Mining",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "CSCI181S",
     "title": "Computational Creativity Seminar",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI181S",
+    "title": "System Security",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI181",
+    "title": "Special Topics in Computer Sci",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -8025,6 +10041,12 @@
     "code": "CSCI181U",
     "title": "Applied Logic/AutomatedReasoning",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI181U",
+    "title": "Building an Internet of Things",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -8046,12 +10068,6 @@
     "credits": 3.0
   },
   {
-    "code": "CSCI182",
-    "title": "Computer Science Seminar",
-    "campus": "hmc",
-    "credits": 3.0
-  },
-  {
     "code": "CSCI182A",
     "title": "Spec Topics: Vision and Robotics",
     "campus": "hmc",
@@ -8066,6 +10082,12 @@
   {
     "code": "CSCI182C",
     "title": "Robotics Outreach Seminar",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI182",
+    "title": "Computer Science Seminar",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -8106,21 +10128,27 @@
     "credits": 3.0
   },
   {
-    "code": "CSCI189",
-    "title": "Programming Practicum",
-    "campus": "hmc",
-    "credits": 3.0
-  },
-  {
     "code": "CSCI189A",
     "title": "Distributed Systems",
     "campus": "po",
     "credits": 3.0
   },
   {
+    "code": "CSCI189",
+    "title": "Programming Practicum",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "CSCI190",
     "title": "Computer Science Senior Seminar",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI191",
+    "title": "Senior Thesis: Computer Science",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -8148,12 +10176,6 @@
     "credits": 3.0
   },
   {
-    "code": "CSCI199",
-    "title": "Independent Study in Comp Sci",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "CSCI199DRPO",
     "title": "Computer Science: Dir Readings",
     "campus": "po",
@@ -8163,6 +10185,12 @@
     "code": "CSCI199IRPO",
     "title": "Computer Science: Indep Research",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CSCI199",
+    "title": "Independent Study in Comp Sci",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -8178,14 +10206,14 @@
     "credits": 3.0
   },
   {
-    "code": "CSMT181",
-    "title": "Special Topics in Comp Sci/Math",
+    "code": "CSMT181A",
+    "title": "Discrete Differential Geometry",
     "campus": "hmc",
     "credits": 3.0
   },
   {
-    "code": "CSMT181A",
-    "title": "Discrete Differential Geometry",
+    "code": "CSMT181",
+    "title": "Special Topics in Comp Sci/Math",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -8215,6 +10243,12 @@
   },
   {
     "code": "DANC013",
+    "title": "Beginning Tap Dance",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "DANC013",
     "title": "Intermediate Tap",
     "campus": "po",
     "credits": 3.0
@@ -8238,12 +10272,6 @@
     "credits": 3.0
   },
   {
-    "code": "DANC076",
-    "title": "Modern Dance I",
-    "campus": "sc",
-    "credits": 3.0
-  },
-  {
     "code": "DANC076A",
     "title": "Modern Dance I",
     "campus": "sc",
@@ -8256,8 +10284,8 @@
     "credits": 3.0
   },
   {
-    "code": "DANC077",
-    "title": "Modern Dance II",
+    "code": "DANC076",
+    "title": "Modern Dance I",
     "campus": "sc",
     "credits": 3.0
   },
@@ -8274,8 +10302,8 @@
     "credits": 3.0
   },
   {
-    "code": "DANC078",
-    "title": "Ballet I",
+    "code": "DANC077",
+    "title": "Modern Dance II",
     "campus": "sc",
     "credits": 3.0
   },
@@ -8287,6 +10315,12 @@
   },
   {
     "code": "DANC078B",
+    "title": "Ballet I",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "DANC078",
     "title": "Ballet I",
     "campus": "sc",
     "credits": 3.0
@@ -8335,13 +10369,19 @@
   },
   {
     "code": "DANC103",
+    "title": "Analyzing Human Movement",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "DANC103",
     "title": "Laban Movement Analysis",
     "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "DANC108",
-    "title": "Movement Improvisation",
+    "code": "DANC103",
+    "title": "Language of the Body",
     "campus": "sc",
     "credits": 3.0
   },
@@ -8358,8 +10398,8 @@
     "credits": 3.0
   },
   {
-    "code": "DANC110",
-    "title": "Ballet II",
+    "code": "DANC108",
+    "title": "Movement Improvisation",
     "campus": "sc",
     "credits": 3.0
   },
@@ -8376,8 +10416,8 @@
     "credits": 3.0
   },
   {
-    "code": "DANC111",
-    "title": "Modern Dance IV",
+    "code": "DANC110",
+    "title": "Ballet II",
     "campus": "sc",
     "credits": 3.0
   },
@@ -8394,8 +10434,8 @@
     "credits": 3.0
   },
   {
-    "code": "DANC112",
-    "title": "Jazz Dance",
+    "code": "DANC111",
+    "title": "Modern Dance IV",
     "campus": "sc",
     "credits": 3.0
   },
@@ -8406,7 +10446,25 @@
     "credits": 3.0
   },
   {
+    "code": "DANC112A",
+    "title": "Jazz Dance II",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "DANC112B",
+    "title": "Jazz Dance",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "DANC112B",
+    "title": "Jazz Dance II",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "DANC112",
     "title": "Jazz Dance",
     "campus": "sc",
     "credits": 3.0
@@ -8418,8 +10476,20 @@
     "credits": 3.0
   },
   {
+    "code": "DANC114A",
+    "title": "Yoga: Evolving Practices",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "DANC114B",
     "title": "Somatics of Yoga",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "DANC114B",
+    "title": "Yoga: Evolving Practices",
     "campus": "sc",
     "credits": 3.0
   },
@@ -8466,6 +10536,12 @@
     "credits": 3.0
   },
   {
+    "code": "DANC130",
+    "title": "The Body and World Performance",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "DANC131",
     "title": "Critical Dance: Gender/Race/Sex",
     "campus": "sc",
@@ -8484,6 +10560,18 @@
     "credits": 3.0
   },
   {
+    "code": "DANC134",
+    "title": "Movement as Culture",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "DANC135",
+    "title": "Introduction West African Dance",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "DANC135",
     "title": "Traditions of World Dance",
     "campus": "po",
@@ -8498,6 +10586,18 @@
   {
     "code": "DANC136B",
     "title": "West Afica Dance II",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "DANC136B",
+    "title": "West African Dance II",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "DANC137",
+    "title": "Latin American Dance Practices",
     "campus": "sc",
     "credits": 3.0
   },
@@ -8526,14 +10626,38 @@
     "credits": 3.0
   },
   {
+    "code": "DANC140",
+    "title": "Music for Dancers",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "DANC141",
     "title": "Composition 2:Choreography Lab",
     "campus": "po",
     "credits": 3.0
   },
   {
+    "code": "DANC141",
+    "title": "Composition: Tools, Structures",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "DANC142",
+    "title": "Feminist Ethnography & Perf",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "DANC142",
     "title": "Improvisation",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "DANC142",
+    "title": "Improvisation Techniques",
     "campus": "po",
     "credits": 3.0
   },
@@ -8592,6 +10716,12 @@
     "credits": 3.0
   },
   {
+    "code": "DANC151",
+    "title": "Dancing Social Justice",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "DANC152",
     "title": "Hip-Hop Dance",
     "campus": "po",
@@ -8622,14 +10752,14 @@
     "credits": 3.0
   },
   {
-    "code": "DANC161",
-    "title": "Choreographing Women's Lives",
+    "code": "DANC160",
+    "title": "Dance Composition II",
     "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "DANC162",
-    "title": "Dance Repertory",
+    "code": "DANC161",
+    "title": "Choreographing Women's Lives",
     "campus": "sc",
     "credits": 3.0
   },
@@ -8642,6 +10772,12 @@
   {
     "code": "DANC162B",
     "title": "Repertory",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "DANC162",
+    "title": "Dance Repertory",
     "campus": "sc",
     "credits": 3.0
   },
@@ -8700,6 +10836,12 @@
     "credits": 3.0
   },
   {
+    "code": "DANC180",
+    "title": "Special Topic in Dance (Studio)",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "DANC181",
     "title": "Dance Repertory",
     "campus": "po",
@@ -8749,14 +10891,14 @@
   },
   {
     "code": "DANC198",
-    "title": "Summer Reading & Research",
-    "campus": "po",
+    "title": "Independent Internship",
+    "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "DANC199",
-    "title": "Independent Study in Dance",
-    "campus": "sc",
+    "code": "DANC198",
+    "title": "Summer Reading & Research",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -8769,6 +10911,12 @@
     "code": "DANC199IRPO",
     "title": "Dance: Independent Research",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "DANC199",
+    "title": "Independent Study in Dance",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -8802,12 +10950,6 @@
     "credits": 3.0
   },
   {
-    "code": "EA",
-    "title": "Envir Analysis:Directed Readings",
-    "campus": "po",
-    "credits": 3.0
-  },
-  {
     "code": "EA010",
     "title": "Intro to Environmental Analysis",
     "campus": "hmc",
@@ -8826,8 +10968,8 @@
     "credits": 3.0
   },
   {
-    "code": "EA030",
-    "title": "Science and the Environment",
+    "code": "EA021",
+    "title": "Nature, Society and Culture",
     "campus": "po",
     "credits": 3.0
   },
@@ -8838,9 +10980,33 @@
     "credits": 3.0
   },
   {
+    "code": "EA030",
+    "title": "Environmental Science",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "EA030L",
     "title": "Science and the Environment",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "EA030",
+    "title": "Lab, Science and the Environment",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "EA030",
+    "title": "Science and the Environment",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "EA031",
+    "title": "Environmental Science-East Asia",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -8886,15 +11052,15 @@
     "credits": 3.0
   },
   {
-    "code": "EA055",
-    "title": "Public Speaking Social Change",
-    "campus": "pz",
-    "credits": 3.0
-  },
-  {
     "code": "EA055L",
     "title": "Phys Geography & Geomorphology",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "EA055",
+    "title": "Public Speaking Social Change",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -8935,6 +11101,12 @@
   },
   {
     "code": "EA085",
+    "title": "Food, Land & The Environment",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "EA085",
     "title": "Food, Land & the Environment",
     "campus": "po",
     "credits": 3.0
@@ -8958,8 +11130,20 @@
     "credits": 3.0
   },
   {
+    "code": "EA090",
+    "title": "Protecting the Sacred",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "EA091",
     "title": "Air Pollution: History & Policy",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "EA091",
+    "title": "Calif. Env. Law,Policy & Politcs",
     "campus": "pz",
     "credits": 3.0
   },
@@ -9000,9 +11184,21 @@
     "credits": 3.0
   },
   {
+    "code": "EA098",
+    "title": "Urban Environments",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "EA099",
     "title": "Sustainability & the Built Envir",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "EA099",
+    "title": "Urban Health Equity",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -9018,8 +11214,32 @@
     "credits": 3.0
   },
   {
+    "code": "EA100L",
+    "title": "Global Climate Change w/Lab",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "EA101",
+    "title": "Environmental Internships",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "EA101",
+    "title": "GIS in Env Analysis, Lab",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "EA101",
     "title": "GIS in Environmental Analysis",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "EA102",
+    "title": "Adv GIS",
     "campus": "po",
     "credits": 3.0
   },
@@ -9030,15 +11250,27 @@
     "credits": 3.0
   },
   {
+    "code": "EA103L",
+    "title": "Principles of Soil Science",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "EA103L",
+    "title": "Soils and Society w/Lab",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "EA103",
     "title": "Soils and Society",
     "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "EA103L",
-    "title": "Principles of Soil Science",
-    "campus": "sc",
+    "code": "EA104",
+    "title": "Doing Natural History",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -9069,6 +11301,12 @@
     "code": "EA110",
     "title": "Agriculture & Enviro Protection",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "EA110",
+    "title": "Experiencing Sustainability",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -9103,6 +11341,12 @@
   },
   {
     "code": "EA131",
+    "title": "Democratizing Community Planning",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "EA131",
     "title": "Restoring Nature",
     "campus": "pz",
     "credits": 3.0
@@ -9122,6 +11366,12 @@
   {
     "code": "EA134",
     "title": "Sustainable Place Studio",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "EA135",
+    "title": "NatureWorks",
     "campus": "pz",
     "credits": 3.0
   },
@@ -9212,6 +11462,12 @@
   {
     "code": "EA156",
     "title": "Hustle & Flow: CA Water Policy",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "EA162",
+    "title": "Gender, Environment & Developmnt",
     "campus": "pz",
     "credits": 3.0
   },
@@ -9354,6 +11610,12 @@
     "credits": 3.0
   },
   {
+    "code": "EA191",
+    "title": "Thesis in Environmental Analysis",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "EA197",
     "title": "Senior Thesis",
     "campus": "pz",
@@ -9366,15 +11628,39 @@
     "credits": 3.0
   },
   {
+    "code": "EA198",
+    "title": "Summer Reading & Research",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "EA199",
     "title": "Indep St: Environmental Analysis",
     "campus": "sc",
     "credits": 3.0
   },
   {
+    "code": "EA199",
+    "title": "Senior Thesis",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "EA999",
     "title": "Independent Study",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "EA",
+    "title": "Envir Analysis: Indep Research",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "EA",
+    "title": "Envir Analysis:Directed Readings",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -9415,8 +11701,20 @@
   },
   {
     "code": "ECON051",
+    "title": "Principles of Macroeconomics",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON051",
     "title": "Principles: Macroeconomics",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON052",
+    "title": "Principles of Microeconomics",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -9450,12 +11748,6 @@
     "credits": 3.0
   },
   {
-    "code": "ECON057",
-    "title": "Economic Statistics",
-    "campus": "po",
-    "credits": 3.0
-  },
-  {
     "code": "ECON057/WISI",
     "title": "Speaking/Writing Intensive Opt",
     "campus": "po",
@@ -9463,6 +11755,12 @@
   },
   {
     "code": "ECON057B",
+    "title": "Economic Statistics",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON057",
     "title": "Economic Statistics",
     "campus": "po",
     "credits": 3.0
@@ -9477,6 +11775,12 @@
     "code": "ECON065",
     "title": "Innovation Management",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON070",
+    "title": "Issues in Environmental Econ",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -9504,6 +11808,12 @@
     "credits": 3.0
   },
   {
+    "code": "ECON086",
+    "title": "Financial Accounting",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ECON087",
     "title": "Accounting & Financial Analysis",
     "campus": "pz",
@@ -9513,6 +11823,12 @@
     "code": "ECON091",
     "title": "Statistics",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON097",
+    "title": "Public Policy Analysis",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -9535,13 +11851,43 @@
   },
   {
     "code": "ECON101",
+    "title": "Intermed Microeconomic Theory",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON101",
     "title": "Intermediate Microeconomics",
     "campus": "cmc",
     "credits": 3.0
   },
   {
+    "code": "ECON101",
+    "title": "Macroeconomic Theory",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON102",
+    "title": "Intermed Macroeconomic Theory",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ECON102",
     "title": "Intermediate Macroeconomics",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON102",
+    "title": "Microeconomic Theory",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON103",
+    "title": "History of Economic Thought",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -9558,9 +11904,27 @@
     "credits": 3.0
   },
   {
+    "code": "ECON104",
+    "title": "Foundations of Political Economy",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON104",
+    "title": "Macroeconomic Theory",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "ECON105",
     "title": "Microeconomic Theory",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON107",
+    "title": "Applied Econometrics",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -9573,6 +11937,12 @@
     "code": "ECON108",
     "title": "GovernmentFiscal&Monetary Policy",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON108",
+    "title": "Markets, Morals & Econ Justice",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -9606,8 +11976,20 @@
     "credits": 3.0
   },
   {
+    "code": "ECON113",
+    "title": "International Economic Relations",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "ECON114",
     "title": "Development of American Economy",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON114",
+    "title": "Development of American Markets",
     "campus": "sc",
     "credits": 3.0
   },
@@ -9624,6 +12006,18 @@
     "credits": 3.0
   },
   {
+    "code": "ECON115",
+    "title": "Labor Economics",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON116",
+    "title": "Race in the U.S. Economy",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ECON116",
     "title": "Race in the US Economy",
     "campus": "po",
@@ -9632,6 +12026,12 @@
   {
     "code": "ECON117",
     "title": "Managerial Acct Finan Analysis",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON118",
+    "title": "Economics of Sports",
     "campus": "po",
     "credits": 3.0
   },
@@ -9648,15 +12048,21 @@
     "credits": 3.0
   },
   {
-    "code": "ECON120",
-    "title": "Statistics",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "ECON120B",
     "title": "History of Economic Analysis",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON120",
+    "title": "Economics of Crime",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON120",
+    "title": "Statistics",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -9666,8 +12072,26 @@
     "credits": 3.0
   },
   {
+    "code": "ECON121",
+    "title": "Economics of Immigration",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON122",
+    "title": "Data Science & Stats Learning",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "ECON122",
     "title": "Poverty & Income Distribution",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON123",
+    "title": "International Economics",
     "campus": "po",
     "credits": 3.0
   },
@@ -9679,8 +12103,26 @@
   },
   {
     "code": "ECON124",
+    "title": "Economics of Latin America",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON124",
+    "title": "Emerging Asia",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON124",
     "title": "Wat. Res. Econ. and Mgmt",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON125",
+    "title": "Econometrics",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -9690,9 +12132,39 @@
     "credits": 3.0
   },
   {
+    "code": "ECON125",
+    "title": "Natural Resource Econ & Policy",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON126",
+    "title": "Applied Microeconometrics",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON126",
+    "title": "Economic Development",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "ECON126",
     "title": "Microeconometrics",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON127",
+    "title": "China & Japan: Economy & Society",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON127",
+    "title": "Environmental Economics",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -9708,9 +12180,21 @@
     "credits": 3.0
   },
   {
+    "code": "ECON128",
+    "title": "Energy Economics, & Policy",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "ECON129",
     "title": "Game Theory",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON129",
+    "title": "Health Economics",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -9727,14 +12211,14 @@
   },
   {
     "code": "ECON132",
-    "title": "Macroeconomic Policy",
-    "campus": "pz",
+    "title": "Empirical Methods of IO",
+    "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "ECON134",
-    "title": "Corporate Finance",
-    "campus": "cmc",
+    "code": "ECON132",
+    "title": "Macroeconomic Policy",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -9750,15 +12234,69 @@
     "credits": 3.0
   },
   {
+    "code": "ECON134",
+    "title": "Corporate Finance",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON134",
+    "title": "Economic Analysis of Politics",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON134",
+    "title": "Money and Banking",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON135",
+    "title": "Analysis Public Projects",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "ECON135",
     "title": "International Economics",
     "campus": "hmc",
     "credits": 3.0
   },
   {
+    "code": "ECON135",
+    "title": "Monetary and Financial Economics",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON135",
+    "title": "Money and Banking",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON135",
+    "title": "Money, Banking and Fin. Markets",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON136",
+    "title": "Derivatives",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "ECON136",
     "title": "Financial Markets and Modeling",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON137",
+    "title": "Healthcare Economics",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -9774,9 +12312,33 @@
     "credits": 3.0
   },
   {
+    "code": "ECON138",
+    "title": "Debt Markets",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON138",
+    "title": "Financial Economics",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON139",
+    "title": "Security Valu & Portfolio Analy",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ECON139",
     "title": "Topics: Investments & Valuation",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON140",
+    "title": "Economic Development",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -9786,9 +12348,33 @@
     "credits": 3.0
   },
   {
+    "code": "ECON140",
+    "title": "Economics of Women Family & Work",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON140",
+    "title": "International Economics",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON140",
+    "title": "The World Economy",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "ECON141",
     "title": "International Economics",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON141",
+    "title": "The Chinese Economy",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -9798,9 +12384,39 @@
     "credits": 3.0
   },
   {
+    "code": "ECON142",
+    "title": "Emerging Econ of Europe & Asia",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON142",
+    "title": "Japanese Economy",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON142",
+    "title": "Pol/Econ of Nat Resource Policy",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "ECON143",
     "title": "The Chinese Economy",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON143",
+    "title": "US Foreign Policy & 3rd World",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON144",
+    "title": "Challenges to Dev in 21st Cent",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -9810,9 +12426,21 @@
     "credits": 3.0
   },
   {
+    "code": "ECON144",
+    "title": "Economic Development",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ECON145",
     "title": "International Money & Finance",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON145",
+    "title": "International Trade",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -9822,9 +12450,27 @@
     "credits": 3.0
   },
   {
+    "code": "ECON146",
+    "title": "International Money & Finance",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "ECON147",
     "title": "Int'l Trade Theory & Policy",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON147",
+    "title": "International Finance",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON147",
+    "title": "International Money and Finance",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -9834,8 +12480,38 @@
     "credits": 3.0
   },
   {
+    "code": "ECON148",
+    "title": "Trade & Development",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON149",
+    "title": "Asian Ecomonic Development",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON149",
+    "title": "Asian Economic Development",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "ECON149",
     "title": "Int'l Acct, Tax & Transfer Price",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON150",
+    "title": "Industrial Organization",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON150",
+    "title": "Intermediate Accounting I",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -9853,8 +12529,20 @@
   },
   {
     "code": "ECON151",
+    "title": "Labor Economics",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON151",
     "title": "Strategic Cost Management",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON152",
+    "title": "Money, Banking & Fin Markets",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -9865,8 +12553,32 @@
   },
   {
     "code": "ECON153",
+    "title": "Corporate Governance Systems",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON153",
     "title": "Intermediate Macroeconomics",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON153",
+    "title": "Urban & Regional Economics",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON154",
+    "title": "Financial Statement Analysis",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON154",
+    "title": "Game Theory for Economists",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -9877,8 +12589,20 @@
   },
   {
     "code": "ECON155",
+    "title": "History of Economic Thought",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON155",
     "title": "Intermediate Accounting II",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON155",
+    "title": "Law and Economics",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -9888,9 +12612,21 @@
     "credits": 3.0
   },
   {
+    "code": "ECON156",
+    "title": "Security Valutn & Portfolio Thry",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "ECON157",
     "title": "Advanced Management & Control",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON157",
+    "title": "Corporate Finance",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -9900,15 +12636,51 @@
     "credits": 3.0
   },
   {
+    "code": "ECON158",
+    "title": "Quantitative Investment Mgmt",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "ECON159",
     "title": "Accounting Theory and Research",
     "campus": "cmc",
     "credits": 3.0
   },
   {
+    "code": "ECON159",
+    "title": "Economics of the Public Sector",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON160",
+    "title": "Accounting Data Analytics",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON160",
+    "title": "African American Economics",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "ECON160",
     "title": "Info Tech & Acct System Design",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON160",
+    "title": "Political Economy of Law",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON161",
+    "title": "Advanced Macroeconomic Analysis",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -9919,8 +12691,26 @@
   },
   {
     "code": "ECON162",
+    "title": "Advanced Microeconomic Analysis",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON162",
     "title": "Internet Economics & Strategy",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON163",
+    "title": "Econ of Poverty & Discrimination",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON163",
+    "title": "International Macroeconomics",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -9936,15 +12726,63 @@
     "credits": 3.0
   },
   {
+    "code": "ECON164",
+    "title": "Technology and Growth",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON165",
+    "title": "Adv Behav & Exper Economics",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON165",
+    "title": "Bus Strategy & Industrial Orgnz",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ECON165",
     "title": "Industrial Organization",
     "campus": "cmc",
     "credits": 3.0
   },
   {
+    "code": "ECON165",
+    "title": "Marxian Political Economy",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON166",
+    "title": "Advanced Topics in Banking",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "ECON166",
     "title": "Empirical Indst Org w/ Practicum",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON166",
+    "title": "Poli Econ of Agrarian Change",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON167",
+    "title": "Econometrics",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON167",
+    "title": "History of Economic Thought",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -9967,8 +12805,20 @@
   },
   {
     "code": "ECON170",
+    "title": "Environmental Economics",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON170",
     "title": "Urban and Regional Economics",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON171",
+    "title": "Econ of Environmental Policy",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -9984,9 +12834,21 @@
     "credits": 3.0
   },
   {
+    "code": "ECON172",
+    "title": "Health Economics",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "ECON173",
     "title": "Economic Development",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON173",
+    "title": "Economics of Innovation",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -9996,9 +12858,33 @@
     "credits": 3.0
   },
   {
+    "code": "ECON174",
+    "title": "Health Economics",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "ECON175",
     "title": "Labor Economics",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON175",
+    "title": "Labor and Personnel Economics",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON175",
+    "title": "Public Finance",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON176",
+    "title": "Economics of the Public Sector",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -10011,12 +12897,6 @@
     "code": "ECON178",
     "title": "Economics of Population",
     "campus": "cmc",
-    "credits": 3.0
-  },
-  {
-    "code": "ECON179",
-    "title": "Special Topics in Economics",
-    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -10044,6 +12924,30 @@
     "credits": 3.0
   },
   {
+    "code": "ECON179",
+    "title": "Special Topics in Economics",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON180",
+    "title": "Economics of Financial Markets",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON180",
+    "title": "Finance",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON180",
+    "title": "Modern Political Economy",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ECON180",
     "title": "Seminar in Research Methods",
     "campus": "cmc",
@@ -10062,15 +12966,15 @@
     "credits": 3.0
   },
   {
-    "code": "ECON183",
-    "title": "Industrial Organization",
-    "campus": "pz",
-    "credits": 3.0
-  },
-  {
     "code": "ECON183E",
     "title": "Freedon, Democracy & Public Pol",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON183",
+    "title": "Industrial Organization",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -10080,8 +12984,26 @@
     "credits": 3.0
   },
   {
+    "code": "ECON184",
+    "title": "Behavioral Finance",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ECON185",
     "title": "Behavioral Finance",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON186",
+    "title": "Economics of Crime",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON186",
+    "title": "Neuroeconomics",
     "campus": "pz",
     "credits": 3.0
   },
@@ -10095,6 +13017,18 @@
     "code": "ECON187",
     "title": "Poverty, Inequality, Discrimnatn",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON187",
+    "title": "Public Finance",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON187",
+    "title": "Sports Economics",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -10116,6 +13050,12 @@
     "credits": 3.0
   },
   {
+    "code": "ECON190",
+    "title": "Senior Seminar in Economics",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "ECON191",
     "title": "Business Law",
     "campus": "cmc",
@@ -10124,6 +13064,12 @@
   {
     "code": "ECON191H",
     "title": "Honors Thesis in Economics",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON191",
+    "title": "Senior Thesis in Economics",
     "campus": "sc",
     "credits": 3.0
   },
@@ -10140,14 +13086,20 @@
     "credits": 3.0
   },
   {
-    "code": "ECON194",
-    "title": "Advanced Microeconomics",
-    "campus": "cmc",
+    "code": "ECON193",
+    "title": "Managerial Economics",
+    "campus": "sc",
     "credits": 3.0
   },
   {
     "code": "ECON194A",
     "title": "Seminar in Investment Management",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON194",
+    "title": "Advanced Microeconomics",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -10170,21 +13122,15 @@
     "credits": 3.0
   },
   {
-    "code": "ECON197",
-    "title": "Independent Study: Economics",
-    "campus": "hmc",
-    "credits": 3.0
-  },
-  {
     "code": "ECON197A",
     "title": "Spec Top:Finan Issues Emerg Mrkt",
     "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "ECON197S",
-    "title": "Special Topics in Economics",
-    "campus": "cmc",
+    "code": "ECON197",
+    "title": "Independent Study: Economics",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -10195,6 +13141,12 @@
   },
   {
     "code": "ECON197SBCM",
+    "title": "Special Topics in Economics",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON197S",
     "title": "Special Topics in Economics",
     "campus": "cmc",
     "credits": 3.0
@@ -10212,9 +13164,21 @@
     "credits": 3.0
   },
   {
-    "code": "ECON199",
-    "title": "Independent Study & Research",
-    "campus": "cmc",
+    "code": "ECON198",
+    "title": "Independent Internship",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON198",
+    "title": "Senior Seminar",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON198",
+    "title": "Summer Reading & Research",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -10230,9 +13194,27 @@
     "credits": 3.0
   },
   {
+    "code": "ECON199",
+    "title": "Independent Study & Research",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON199",
+    "title": "Independent Study in Economics",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ECON199RAPO",
     "title": "Economics:Research Assistantship",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON199",
+    "title": "Senior Thesis",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -10267,6 +13249,12 @@
   },
   {
     "code": "ECON313",
+    "title": "Microeconomic Analysis",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON313",
     "title": "Microeconomic Analysis I",
     "campus": "cgu",
     "credits": 3.0
@@ -10280,6 +13268,12 @@
   {
     "code": "ECON317",
     "title": "Advanced Microeconomics II",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "ECON317",
+    "title": "Game Theory & Asymmetric Info",
     "campus": "cgu",
     "credits": 3.0
   },
@@ -10332,14 +13326,14 @@
     "credits": 3.0
   },
   {
-    "code": "ECON350",
-    "title": "Global Money & Finance",
+    "code": "ECON350EECG",
+    "title": "Designing High Performance Neur",
     "campus": "cgu",
     "credits": 3.0
   },
   {
-    "code": "ECON350EECG",
-    "title": "Designing High Performance Neur",
+    "code": "ECON350",
+    "title": "Global Money & Finance",
     "campus": "cgu",
     "credits": 3.0
   },
@@ -10398,13 +13392,13 @@
     "credits": 3.0
   },
   {
-    "code": "EDUC170",
+    "code": "EDUC170G",
     "title": "Intro to Public School Teaching",
     "campus": "cgu",
     "credits": 3.0
   },
   {
-    "code": "EDUC170G",
+    "code": "EDUC170",
     "title": "Intro to Public School Teaching",
     "campus": "cgu",
     "credits": 3.0
@@ -10434,8 +13428,8 @@
     "credits": 3.0
   },
   {
-    "code": "EDUC301",
-    "title": "Teach/Learn Process I - Elemntry",
+    "code": "EDUC301GSCG",
+    "title": "Teach/Learn Process I: Spec Educ",
     "campus": "cgu",
     "credits": 3.0
   },
@@ -10446,20 +13440,14 @@
     "credits": 3.0
   },
   {
-    "code": "EDUC301GSCG",
-    "title": "Teach/Learn Process I: Spec Educ",
-    "campus": "cgu",
-    "credits": 3.0
-  },
-  {
     "code": "EDUC301SPCG",
     "title": "Teach/Learn Process I - Spec Ed",
     "campus": "cgu",
     "credits": 3.0
   },
   {
-    "code": "EDUC302",
-    "title": "Teaching/Learning Proc I-Seconda",
+    "code": "EDUC301",
+    "title": "Teach/Learn Process I - Elemntry",
     "campus": "cgu",
     "credits": 3.0
   },
@@ -10470,8 +13458,20 @@
     "credits": 3.0
   },
   {
+    "code": "EDUC302",
+    "title": "Teaching/Learning Proc I-Seconda",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
     "code": "EDUC398",
     "title": "Independent Study",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "EDUC407",
+    "title": "Educational Policy",
     "campus": "cgu",
     "credits": 3.0
   },
@@ -10669,6 +13669,18 @@
   },
   {
     "code": "ENGL003",
+    "title": "B(L)ack to Nature: Bird Watching",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL003",
+    "title": "Transatlantic Black/Asian Film",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL003",
     "title": "Transatlantic Blk/Asian Film/Lit",
     "campus": "pz",
     "credits": 3.0
@@ -10676,6 +13688,12 @@
   {
     "code": "ENGL006",
     "title": "Beyond Bars: Against Mass Incar",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL009",
+    "title": "Black Feminist Community Lrning",
     "campus": "pz",
     "credits": 3.0
   },
@@ -10710,14 +13728,14 @@
     "credits": 3.0
   },
   {
-    "code": "ENGL012",
-    "title": "Intro to Afr-Amer Lit after 1865",
+    "code": "ENGL012A",
+    "title": "Intr to Afr Amer Lit Before 1865",
     "campus": "pz",
     "credits": 3.0
   },
   {
-    "code": "ENGL012A",
-    "title": "Intr to Afr Amer Lit Before 1865",
+    "code": "ENGL012B",
+    "title": "Intro to Afr Amer Lit After 1865",
     "campus": "pz",
     "credits": 3.0
   },
@@ -10728,8 +13746,14 @@
     "credits": 3.0
   },
   {
-    "code": "ENGL014",
-    "title": "Intro to African Lit and Film",
+    "code": "ENGL012",
+    "title": "Intro to Afr-Amer Lit after 1865",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL012",
+    "title": "Intro to African-American Lit",
     "campus": "pz",
     "credits": 3.0
   },
@@ -10746,8 +13770,8 @@
     "credits": 3.0
   },
   {
-    "code": "ENGL015",
-    "title": "Intro to World Literature",
+    "code": "ENGL014",
+    "title": "Intro to African Lit and Film",
     "campus": "pz",
     "credits": 3.0
   },
@@ -10760,6 +13784,12 @@
   {
     "code": "ENGL015B",
     "title": "Intro to 20th C World Literature",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL015",
+    "title": "Intro to World Literature",
     "campus": "pz",
     "credits": 3.0
   },
@@ -10806,12 +13836,6 @@
     "credits": 3.0
   },
   {
-    "code": "ENGL030",
-    "title": "Introduction to Creative Writing",
-    "campus": "pz",
-    "credits": 3.0
-  },
-  {
     "code": "ENGL030A",
     "title": "Intro Creative Writing: Poetry",
     "campus": "pz",
@@ -10830,8 +13854,20 @@
     "credits": 3.0
   },
   {
+    "code": "ENGL030",
+    "title": "Introduction to Creative Writing",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL031",
     "title": "Intro Fiction & Nonfiction",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL031",
+    "title": "Introduction to Fiction Writing",
     "campus": "pz",
     "credits": 3.0
   },
@@ -10850,6 +13886,12 @@
   {
     "code": "ENGL034",
     "title": "Intrmd Crea Writing: Fiction",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL035",
+    "title": "Community Literary Practices",
     "campus": "pz",
     "credits": 3.0
   },
@@ -10903,8 +13945,20 @@
   },
   {
     "code": "ENGL050",
+    "title": "Irish Literary Revival",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL050",
     "title": "Modern British & Irish Fiction",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL051",
+    "title": "Literature of the Supernatural",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -10926,12 +13980,6 @@
     "credits": 3.0
   },
   {
-    "code": "ENGL055",
-    "title": "Southern Literary Renaissance",
-    "campus": "pz",
-    "credits": 3.0
-  },
-  {
     "code": "ENGL055A",
     "title": "Impossible Novels",
     "campus": "po",
@@ -10947,6 +13995,12 @@
     "code": "ENGL055C",
     "title": "Westerns and Gold",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL055",
+    "title": "Southern Literary Renaissance",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -11004,8 +14058,20 @@
     "credits": 3.0
   },
   {
+    "code": "ENGL064D",
+    "title": "Screenwriting",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL064E",
     "title": "Literary Translation",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL065",
+    "title": "Alchemical Cartography",
     "campus": "po",
     "credits": 3.0
   },
@@ -11058,9 +14124,21 @@
     "credits": 3.0
   },
   {
+    "code": "ENGL074",
+    "title": "US Sports Literature",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL075",
     "title": "British Novel II",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL075",
+    "title": "Contemp. Chicana/o Literature",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -11103,12 +14181,6 @@
     "code": "ENGL088",
     "title": "Poets in the 21st Century",
     "campus": "po",
-    "credits": 3.0
-  },
-  {
-    "code": "ENGL089",
-    "title": "U.S. Latino Literature",
-    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -11172,14 +14244,32 @@
     "credits": 3.0
   },
   {
+    "code": "ENGL089",
+    "title": "U.S. Latino Literature",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL090A",
+    "title": "Comic Tradition in Irish Ficton",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL090",
+    "title": "Alienation & Exile in Mod World",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL090",
     "title": "Medieval and Renaissance Lit.",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "ENGL090A",
-    "title": "Comic Tradition in Irish Ficton",
+    "code": "ENGL091",
+    "title": "Cross Borders, Rites of Passage",
     "campus": "pz",
     "credits": 3.0
   },
@@ -11196,9 +14286,27 @@
     "credits": 3.0
   },
   {
+    "code": "ENGL092",
+    "title": "City as Character in Lit & Film",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL093",
     "title": "Rock & Roll Writing",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL093",
+    "title": "World Lit in an Oceanic Context",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL094",
+    "title": "Growing Up Postcolonial\"\"",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -11226,14 +14334,20 @@
     "credits": 3.0
   },
   {
+    "code": "ENGL099",
+    "title": "The Idea of the Renaissance",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL100",
     "title": "Lit/Cultures of US Imperialism",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "ENGL101",
-    "title": "Modern Cuban Literature and Film",
+    "code": "ENGL100",
+    "title": "Modernity Globaliztn Urbanizatn",
     "campus": "pz",
     "credits": 3.0
   },
@@ -11250,8 +14364,14 @@
     "credits": 3.0
   },
   {
-    "code": "ENGL102",
-    "title": "Readings in American Literature",
+    "code": "ENGL101",
+    "title": "Modern Cuban Literature and Film",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL101",
+    "title": "Readings in British Literature",
     "campus": "sc",
     "credits": 3.0
   },
@@ -11268,9 +14388,39 @@
     "credits": 3.0
   },
   {
+    "code": "ENGL102",
+    "title": "Readings in American Literature",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL103",
+    "title": "Afro-Futurism Black Sci-Fi",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL103",
     "title": "Literature of the Enlightenment",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL103",
+    "title": "Survey of American Lit:1900-1945",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL104",
+    "title": "Challenging Race in Black Lit",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL104",
+    "title": "Intro to Poetry & Poetics",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -11287,14 +14437,14 @@
   },
   {
     "code": "ENGL107",
-    "title": "William Blake",
-    "campus": "po",
+    "title": "Harlem & Sophiatown Renaissance",
+    "campus": "pz",
     "credits": 3.0
   },
   {
-    "code": "ENGL108",
-    "title": "Latino Literature",
-    "campus": "pz",
+    "code": "ENGL107",
+    "title": "William Blake",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -11304,9 +14454,27 @@
     "credits": 3.0
   },
   {
+    "code": "ENGL108",
+    "title": "Latino Literature",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL108",
+    "title": "The Essay as Resistance",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL109",
     "title": "Intro to Performance Studies",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL109",
+    "title": "Lit and Film of African Diaspora",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -11322,15 +14490,45 @@
     "credits": 3.0
   },
   {
+    "code": "ENGL111",
+    "title": "Love & Loss in Brit Lit 1750-Pr",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL111",
+    "title": "Shakespeare Comedies & Histories",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL112",
     "title": "Early Modern Romance",
     "campus": "po",
     "credits": 3.0
   },
   {
+    "code": "ENGL112",
+    "title": "Rule Britannia: Imperial Vic Lit",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL112",
+    "title": "Shakespeare:Tragedies & Romances",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL113",
     "title": "Race/Gendr/Pop Culture 1865-1917",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL113",
+    "title": "Vampires in Literature  & Film",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -11346,9 +14544,33 @@
     "credits": 3.0
   },
   {
+    "code": "ENGL115",
+    "title": "On Form: Sonnets and Epigrams",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL116",
+    "title": "Early Modern Outsiders",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL116",
     "title": "Excess: Lit/Phil/Psychoanalysis",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL116",
+    "title": "Joyce, Woolf, and Faulkner",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL117",
+    "title": "Contemporary American Fiction",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -11370,15 +14592,21 @@
     "credits": 3.0
   },
   {
-    "code": "ENGL120",
-    "title": "Studies in Drama: Greek Tragedy",
-    "campus": "pz",
-    "credits": 3.0
-  },
-  {
     "code": "ENGL120A",
     "title": "19th Century American Literature",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL120",
+    "title": "Eighteenth-Century British Lit",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL120",
+    "title": "Studies in Drama: Greek Tragedy",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -11388,14 +14616,20 @@
     "credits": 3.0
   },
   {
-    "code": "ENGL122",
-    "title": "Healing Narratives",
-    "campus": "po",
+    "code": "ENGL121",
+    "title": "The Satirical Imagination",
+    "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "ENGL123",
-    "title": "Holocaust in Literature & Film",
+    "code": "ENGL122",
+    "title": "Gothic Fiction",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL122",
+    "title": "Healing Narratives",
     "campus": "po",
     "credits": 3.0
   },
@@ -11412,14 +14646,32 @@
     "credits": 3.0
   },
   {
+    "code": "ENGL123",
+    "title": "Holocaust in Literature & Film",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL123",
+    "title": "Romantic Literature",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL123",
+    "title": "Satire in Literature and Film",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL124",
     "title": "AfroFuturisms",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "ENGL125",
-    "title": "Literary Theory",
+    "code": "ENGL124",
+    "title": "The Bible and Homer",
     "campus": "pz",
     "credits": 3.0
   },
@@ -11430,15 +14682,33 @@
     "credits": 3.0
   },
   {
+    "code": "ENGL125DLAF",
+    "title": "Lit/Film of African Diaspora Lab",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL125D",
     "title": "Lit and Film of African Diaspora",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "ENGL125DLAF",
-    "title": "Lit/Film of African Diaspora Lab",
-    "campus": "po",
+    "code": "ENGL125",
+    "title": "Literary Theory",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL125",
+    "title": "Victorian Novel",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL126",
+    "title": "Activist Poetics",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -11461,19 +14731,31 @@
   },
   {
     "code": "ENGL129",
-    "title": "Spaces of Cultural Resistance",
-    "campus": "po",
+    "title": "Literature of the Fin de Siecle",
+    "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "ENGL130",
-    "title": "Topics 20th C Afr Diaspora Lit",
+    "code": "ENGL129",
+    "title": "Poetry and Public Space",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL129",
+    "title": "Spaces of Cultural Resistance",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ENGL130A",
     "title": "Adv Creative Writing: Poetry",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL130",
+    "title": "Adv Projects in Creative Writing",
     "campus": "pz",
     "credits": 3.0
   },
@@ -11490,8 +14772,26 @@
     "credits": 3.0
   },
   {
+    "code": "ENGL130",
+    "title": "Character and the Novel",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL130D",
     "title": "Adv Creative Writ: Writ Diaspora",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL130",
+    "title": "Topics 20th C Afr Diaspora Lit",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL131A",
+    "title": "Art of Writing for the Screen",
     "campus": "pz",
     "credits": 3.0
   },
@@ -11502,14 +14802,20 @@
     "credits": 3.0
   },
   {
-    "code": "ENGL131A",
-    "title": "Art of Writing for the Screen",
+    "code": "ENGL131B",
+    "title": "Adv Creative Writing: Fiction",
     "campus": "pz",
     "credits": 3.0
   },
   {
-    "code": "ENGL131B",
-    "title": "Adv Creative Writing: Fiction",
+    "code": "ENGL131",
+    "title": "Modern British Novel",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL132",
+    "title": "Black Queer Narrative & Theories",
     "campus": "pz",
     "credits": 3.0
   },
@@ -11520,8 +14826,20 @@
     "credits": 3.0
   },
   {
+    "code": "ENGL132",
+    "title": "Contemporary Speculative Fiction",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL132S",
     "title": "Hardy and Lawrence",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL133S",
+    "title": "Virginia Woolf",
     "campus": "sc",
     "credits": 3.0
   },
@@ -11532,15 +14850,15 @@
     "credits": 3.0
   },
   {
-    "code": "ENGL133S",
-    "title": "Virginia Woolf",
+    "code": "ENGL134",
+    "title": "Gothic Fiction",
     "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "ENGL134",
-    "title": "Gothic Fiction",
-    "campus": "sc",
+    "code": "ENGL135",
+    "title": "Advncd Feminist Creative Writing",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -11550,20 +14868,26 @@
     "credits": 3.0
   },
   {
+    "code": "ENGL135",
+    "title": "The Satirical Imagination",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL136",
     "title": "Feminist Poetics",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "ENGL137",
-    "title": "Fragment as Form",
+    "code": "ENGL137A",
+    "title": "Invention of Asian-American Lit",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "ENGL137A",
-    "title": "Invention of Asian-American Lit",
+    "code": "ENGL137",
+    "title": "Fragment as Form",
     "campus": "po",
     "credits": 3.0
   },
@@ -11580,8 +14904,32 @@
     "credits": 3.0
   },
   {
+    "code": "ENGL140",
+    "title": "Victorian Hunger",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL141",
     "title": "Shakespearean Drama",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL141",
+    "title": "The Slave Narrative & the Novel",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL142",
+    "title": "Feminist and Queer Theories",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL142",
+    "title": "Literature and The Commons",
     "campus": "po",
     "credits": 3.0
   },
@@ -11592,14 +14940,26 @@
     "credits": 3.0
   },
   {
-    "code": "ENGL143",
-    "title": "Victorian Novel",
+    "code": "ENGL142",
+    "title": "The Early American Novel",
     "campus": "sc",
     "credits": 3.0
   },
   {
     "code": "ENGL143S",
     "title": "Antebellum Lit & Pop Culture",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL143",
+    "title": "Victorian Novel",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL144",
+    "title": "Melville & Douglass",
     "campus": "sc",
     "credits": 3.0
   },
@@ -11611,7 +14971,25 @@
   },
   {
     "code": "ENGL145",
+    "title": "American Women Writers",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL145",
     "title": "Gothic Tradition",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL145",
+    "title": "Modern Mexican Literature & Film",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL146",
+    "title": "Asian American Poetry",
     "campus": "po",
     "credits": 3.0
   },
@@ -11634,6 +15012,12 @@
     "credits": 3.0
   },
   {
+    "code": "ENGL147",
+    "title": "Victorian Literature",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL148",
     "title": "Literary Theory,Ancient & Modern",
     "campus": "po",
@@ -11641,8 +15025,26 @@
   },
   {
     "code": "ENGL149",
+    "title": "British Detective Lit",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL149",
     "title": "Korea's IMF-Crisis Cinema",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL149",
+    "title": "Literature of the Fin de Siecle",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL150",
+    "title": "Character and the Novel",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -11653,8 +15055,32 @@
   },
   {
     "code": "ENGL151",
+    "title": "American Modernism",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL151",
+    "title": "British Women Writrs Before 1900",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL151",
+    "title": "Medieval Proof",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL151",
     "title": "Topics in Medieval Lit & Culture",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL152",
+    "title": "Hardy and Lawrence",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -11664,9 +15090,33 @@
     "credits": 3.0
   },
   {
+    "code": "ENGL152",
+    "title": "Nature in 19th C British Lit",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL153",
     "title": "Medieval Nonsense",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL153",
+    "title": "Performing Literature",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL153",
+    "title": "The Beyond of Language",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL153",
+    "title": "Virginia Woolf",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -11676,15 +15126,57 @@
     "credits": 3.0
   },
   {
+    "code": "ENGL154",
+    "title": "Novel on Screen",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL154",
+    "title": "Shakespeare:Comedies & Histories",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL155",
+    "title": "Contemporary British Literature",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL155",
+    "title": "Multi-Ethnic Lit of the US",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL155",
     "title": "Shakespeare:Tragedies & Romances",
     "campus": "po",
     "credits": 3.0
   },
   {
+    "code": "ENGL155",
+    "title": "Victorian Monsters",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL156",
+    "title": "Legal Fictions",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL156",
     "title": "Milton and Visual Culture",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL157",
+    "title": "James Baldwin",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -11696,12 +15188,6 @@
   {
     "code": "ENGL158",
     "title": "Jane Austen",
-    "campus": "po",
-    "credits": 3.0
-  },
-  {
-    "code": "ENGL159",
-    "title": "Supernatural Century",
     "campus": "po",
     "credits": 3.0
   },
@@ -11730,6 +15216,18 @@
     "credits": 3.0
   },
   {
+    "code": "ENGL159",
+    "title": "Ethics & Dread in Victorian Lit",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL159",
+    "title": "Supernatural Century",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL160",
     "title": "Literature of the Americas",
     "campus": "pz",
@@ -11743,8 +15241,26 @@
   },
   {
     "code": "ENGL161",
+    "title": "Asian American Fiction",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL161",
+    "title": "Futures of Asian/America",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL161",
     "title": "James Joyce",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL162",
+    "title": "Asian Amer Lit:Gender+Sexuality",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -11761,8 +15277,26 @@
   },
   {
     "code": "ENGL164",
+    "title": "Essay and Experiment",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL164",
     "title": "Harlem Renaissance",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL164",
+    "title": "Melville & Douglass",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL164",
+    "title": "W.B. Yeats: Poetry and Drama",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -11773,14 +15307,26 @@
   },
   {
     "code": "ENGL166",
+    "title": "American Modernism",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL166",
     "title": "James Baldwin",
     "campus": "pz",
     "credits": 3.0
   },
   {
-    "code": "ENGL167",
-    "title": "Writing and Exile",
+    "code": "ENGL166",
+    "title": "Literature, Illness & Disability",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL167",
+    "title": "20th C Jewish-American Literatur",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -11792,6 +15338,12 @@
   {
     "code": "ENGL167B",
     "title": "Contemporary Chicana/o Lit",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL167B",
+    "title": "Contemporary Chicanx Literature",
     "campus": "sc",
     "credits": 3.0
   },
@@ -11808,6 +15360,24 @@
     "credits": 3.0
   },
   {
+    "code": "ENGL167D",
+    "title": "Chicanx Short Fiction",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL167",
+    "title": "Writing and Exile",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL168",
+    "title": "Contemporary American Poetry",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL168",
     "title": "Writing Machines",
     "campus": "po",
@@ -11820,14 +15390,14 @@
     "credits": 3.0
   },
   {
-    "code": "ENGL170",
-    "title": "Advanced Studies Seminar English",
+    "code": "ENGL170A",
+    "title": "Anglo-Am Literary Modernism",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "ENGL170A",
-    "title": "Anglo-Am Literary Modernism",
+    "code": "ENGL170",
+    "title": "Advanced Studies Seminar English",
     "campus": "po",
     "credits": 3.0
   },
@@ -11856,6 +15426,18 @@
     "credits": 3.0
   },
   {
+    "code": "ENGL170",
+    "title": "Empire & Education in US Lit",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL170",
+    "title": "Feminist Literary Theory",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL170G",
     "title": "Shakespeare Seminar",
     "campus": "po",
@@ -11874,6 +15456,12 @@
     "credits": 3.0
   },
   {
+    "code": "ENGL170J",
+    "title": "The Works of Toni Morrison",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL170K",
     "title": "The Canterbury Tales",
     "campus": "po",
@@ -11882,6 +15470,12 @@
   {
     "code": "ENGL170L",
     "title": "The Other Chaucer",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL170",
+    "title": "Legal Guardianship and the Novel",
     "campus": "po",
     "credits": 3.0
   },
@@ -11928,14 +15522,32 @@
     "credits": 3.0
   },
   {
+    "code": "ENGL171S",
+    "title": "The Postcolonial Novel",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL171",
     "title": "Sports in Literature and Culture",
     "campus": "pz",
     "credits": 3.0
   },
   {
-    "code": "ENGL171S",
-    "title": "The Postcolonial Novel",
+    "code": "ENGL172",
+    "title": "Queer Postcolonial Lit & Theory",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL172",
+    "title": "Race/Gender in Postcolonial Lit",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL172S",
+    "title": "Queer Postcolonial Lit & Theory",
     "campus": "sc",
     "credits": 3.0
   },
@@ -11946,15 +15558,21 @@
     "credits": 3.0
   },
   {
-    "code": "ENGL172S",
-    "title": "Queer Postcolonial Lit & Theory",
-    "campus": "sc",
+    "code": "ENGL173",
+    "title": "Desire in Literature & Culture",
+    "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "ENGL173",
-    "title": "Desire in Literature & Culture",
-    "campus": "pz",
+    "title": "Human Rights & World Literature",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL174",
+    "title": "Contemporary Women Writers",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -11977,6 +15595,12 @@
   },
   {
     "code": "ENGL177",
+    "title": "Caribbean Lit & Postcol Theory",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL177",
     "title": "The Memoir",
     "campus": "sc",
     "credits": 3.0
@@ -11985,6 +15609,24 @@
     "code": "ENGL180",
     "title": "Seminar in Literary Theory",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL181",
+    "title": "Decolonial Futures",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL181",
+    "title": "Intro Marxist Literary Criticism",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL181",
+    "title": "Postcolonial Studies 21st Centry",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -12000,8 +15642,8 @@
     "credits": 3.0
   },
   {
-    "code": "ENGL183",
-    "title": "Gendered Prose",
+    "code": "ENGL182",
+    "title": "Politics & Aesthetics",
     "campus": "sc",
     "credits": 3.0
   },
@@ -12030,9 +15672,9 @@
     "credits": 3.0
   },
   {
-    "code": "ENGL184",
-    "title": "New Poetics",
-    "campus": "po",
+    "code": "ENGL183",
+    "title": "Gendered Prose",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -12054,15 +15696,33 @@
     "credits": 3.0
   },
   {
+    "code": "ENGL184C",
+    "title": "Seminar in Chicana/o Literature",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL184D",
     "title": "Chicana/o Short Fiction",
     "campus": "sc",
     "credits": 3.0
   },
   {
+    "code": "ENGL184",
+    "title": "New Poetics",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL184O",
     "title": "US Central American Literature",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL184",
+    "title": "Seminar: 19thC Western Realism",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -12090,8 +15750,20 @@
     "credits": 3.0
   },
   {
+    "code": "ENGL186",
+    "title": "Post-Apartheid Novels",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL187",
     "title": "Nuruddin Farah",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL187",
+    "title": "Race/Gender in Postcolonial Lit",
     "campus": "sc",
     "credits": 3.0
   },
@@ -12108,9 +15780,9 @@
     "credits": 3.0
   },
   {
-    "code": "ENGL189",
-    "title": "Postmodernism",
-    "campus": "pz",
+    "code": "ENGL189A",
+    "title": "John Ashbery",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -12126,6 +15798,12 @@
     "credits": 3.0
   },
   {
+    "code": "ENGL189B",
+    "title": "Introduction to Literary Theory",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL189C",
     "title": "Abraham and Paul",
     "campus": "po",
@@ -12135,6 +15813,12 @@
     "code": "ENGL189D",
     "title": "Literature and Social Theory",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL189",
+    "title": "Fifties Film:Pop Culture Society",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -12156,15 +15840,27 @@
     "credits": 3.0
   },
   {
+    "code": "ENGL189",
+    "title": "Postmodernism",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL190",
+    "title": "Intro to Creative Writing",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL190",
     "title": "Senior Exercise/Seminar Option",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "ENGL191",
-    "title": "Senior Thesis",
-    "campus": "po",
+    "code": "ENGL190",
+    "title": "Senior Seminar in English",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -12174,14 +15870,26 @@
     "credits": 3.0
   },
   {
-    "code": "ENGL192",
-    "title": "Literature of Transnationalism",
+    "code": "ENGL191",
+    "title": "Modernism",
     "campus": "pz",
     "credits": 3.0
   },
   {
-    "code": "ENGL193",
-    "title": "Fictions of James Joyce",
+    "code": "ENGL191",
+    "title": "Poetry Writing Workshop",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL191",
+    "title": "Senior Thesis",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL192",
+    "title": "Literature of Transnationalism",
     "campus": "pz",
     "credits": 3.0
   },
@@ -12192,9 +15900,21 @@
     "credits": 3.0
   },
   {
-    "code": "ENGL194",
-    "title": "Terror and the Text",
+    "code": "ENGL193",
+    "title": "Fiction Writing Workshop",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL193",
+    "title": "Fictions of James Joyce",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL193",
+    "title": "Intro to Fiction Writing",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -12204,9 +15924,21 @@
     "credits": 3.0
   },
   {
+    "code": "ENGL194",
+    "title": "Terror and the Text",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL195",
     "title": "Criticism: Advanced Methods",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL195",
+    "title": "Women in Ancient Indian Lit",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -12247,13 +15979,13 @@
   },
   {
     "code": "ENGL198",
-    "title": "Senior & Junior Seminar",
-    "campus": "pz",
+    "title": "Independent Internship",
+    "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "ENGL199",
-    "title": "Senior Thesis",
+    "code": "ENGL198",
+    "title": "Senior & Junior Seminar",
     "campus": "pz",
     "credits": 3.0
   },
@@ -12282,9 +16014,21 @@
     "credits": 3.0
   },
   {
+    "code": "ENGL199",
+    "title": "Independent Study in English",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ENGL199RAPO",
     "title": "English: Research Assistantship",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGL199",
+    "title": "Senior Thesis",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -12438,14 +16182,14 @@
     "credits": 3.0
   },
   {
-    "code": "ENGR085",
-    "title": "Digital Elec & Comp Engineering",
+    "code": "ENGR085A",
+    "title": "Digital Electronics",
     "campus": "hmc",
     "credits": 3.0
   },
   {
-    "code": "ENGR085A",
-    "title": "Digital Electronics",
+    "code": "ENGR085",
+    "title": "Digital Elec & Comp Engineering",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -12458,6 +16202,12 @@
   {
     "code": "ENGR091",
     "title": "Intermediate Problems in Enginrg",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGR101",
+    "title": "Advanced Systems Engineering",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -12600,6 +16350,12 @@
     "credits": 3.0
   },
   {
+    "code": "ENGR151",
+    "title": "Engineering Electronics",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "ENGR153",
     "title": "Electronics Laboratory",
     "campus": "hmc",
@@ -12654,13 +16410,13 @@
     "credits": 3.0
   },
   {
-    "code": "ENGR168",
+    "code": "ENGR168A",
     "title": "Fiber Optic Communications",
     "campus": "hmc",
     "credits": 3.0
   },
   {
-    "code": "ENGR168A",
+    "code": "ENGR168",
     "title": "Fiber Optic Communications",
     "campus": "hmc",
     "credits": 3.0
@@ -12758,12 +16514,6 @@
   {
     "code": "ENGR189",
     "title": "Corp Envr Strtgy/Perf Measuremnt",
-    "campus": "hmc",
-    "credits": 3.0
-  },
-  {
-    "code": "ENGR190",
-    "title": "Special Topics in Engineering",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -12924,14 +16674,14 @@
     "credits": 3.0
   },
   {
-    "code": "ENGR190F",
-    "title": "Engineering Design & Invention",
+    "code": "ENGR190F2HM",
+    "title": "Engineering Design & Invention 2",
     "campus": "hmc",
     "credits": 3.0
   },
   {
-    "code": "ENGR190F2HM",
-    "title": "Engineering Design & Invention 2",
+    "code": "ENGR190F",
+    "title": "Engineering Design & Invention",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -12962,6 +16712,12 @@
   {
     "code": "ENGR190R",
     "title": "Reliability/Maintainability/Test",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGR190",
+    "title": "Special Topics in Engineering",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -12998,6 +16754,12 @@
   {
     "code": "ENGR190Y",
     "title": "Full Scale System Perform Eval",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ENGR190Z",
+    "title": "Risk Management",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -13188,14 +16950,14 @@
     "credits": 3.0
   },
   {
-    "code": "FGSS188",
-    "title": "Advanced Topics Fem Gendr Sex St",
+    "code": "FGSS188A",
+    "title": "Adv Top: Historicizing Queerness",
     "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "FGSS188A",
-    "title": "Adv Top: Historicizing Queerness",
+    "code": "FGSS188",
+    "title": "Advanced Topics Fem Gendr Sex St",
     "campus": "sc",
     "credits": 3.0
   },
@@ -13214,6 +16976,12 @@
   {
     "code": "FGSS189",
     "title": "Feminist & Queer Research Meth",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "FGSS190",
+    "title": "Feminist & Queer Creatv Methods",
     "campus": "sc",
     "credits": 3.0
   },
@@ -13315,8 +17083,32 @@
   },
   {
     "code": "FREN002",
+    "title": "Continued Introductory French",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "FREN002",
     "title": "Continuing Introductory French",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "FREN002",
+    "title": "Introductory French",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "FREN002L",
+    "title": "Cont Inro French Conv Class",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "FREN002L",
+    "title": "Cont Intro French Conv Class",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -13340,6 +17132,12 @@
   {
     "code": "FREN015",
     "title": "Advanced Plus Conversation",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "FREN022",
+    "title": "Intensive Elementary French",
     "campus": "po",
     "credits": 3.0
   },
@@ -13369,6 +17167,12 @@
   },
   {
     "code": "FREN041",
+    "title": "Advanced French",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "FREN044",
     "title": "Advanced French",
     "campus": "po",
     "credits": 3.0
@@ -13410,6 +17214,12 @@
     "credits": 3.0
   },
   {
+    "code": "FREN103",
+    "title": "Frenchness: May '68-2018",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "FREN104",
     "title": "History, Memory & Loss: Vichy",
     "campus": "sc",
@@ -13419,6 +17229,12 @@
     "code": "FREN105",
     "title": "Culture, Phonetics, and Style",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "FREN106",
+    "title": "French Business World & Language",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -13440,6 +17256,12 @@
     "credits": 3.0
   },
   {
+    "code": "FREN108",
+    "title": "Notre-Dame de Paris",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "FREN109",
     "title": "Intro to French Linguistics",
     "campus": "po",
@@ -13447,8 +17269,20 @@
   },
   {
     "code": "FREN110",
+    "title": "France in the 'Hood",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "FREN110",
     "title": "French Films",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "FREN110",
+    "title": "Liberte, Egalite, Fraternite?",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -13461,6 +17295,12 @@
     "code": "FREN112",
     "title": "Le Theatre Francophone",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "FREN113",
+    "title": "Banned in France",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -13485,6 +17325,12 @@
     "code": "FREN116",
     "title": "Display, Desire & Domination",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "FREN117",
+    "title": "African Novel and Film",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -13536,14 +17382,32 @@
     "credits": 3.0
   },
   {
+    "code": "FREN124",
+    "title": "Writings of Freedom & Desire",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "FREN125",
     "title": "Introduction to French Poetry",
     "campus": "sc",
     "credits": 3.0
   },
   {
+    "code": "FREN125",
+    "title": "The French Detective",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "FREN126",
     "title": "Paris: Capitale des Arts",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "FREN127",
+    "title": "French Contemp Women Directors",
     "campus": "sc",
     "credits": 3.0
   },
@@ -13557,6 +17421,12 @@
     "code": "FREN128",
     "title": "The Fantastic",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "FREN128",
+    "title": "Writing Memory",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -13602,8 +17472,20 @@
     "credits": 3.0
   },
   {
+    "code": "FREN135",
+    "title": "The Art of the Short Story",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "FREN137",
     "title": "Algerian War & Fr Intelligentsia",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "FREN137",
+    "title": "The Algerian War",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -13669,6 +17551,12 @@
   },
   {
     "code": "FREN152",
+    "title": "Literature as Resistance",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "FREN152",
     "title": "Masters, Servants, & Slaves",
     "campus": "po",
     "credits": 3.0
@@ -13728,6 +17616,24 @@
     "credits": 3.0
   },
   {
+    "code": "FREN173",
+    "title": "Wit/Ridicule in the French Salon",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "FREN173",
+    "title": "Within the French Salon",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "FREN174",
+    "title": "Adultery in the Novel",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "FREN174",
     "title": "The Romantic Others",
     "campus": "po",
@@ -13770,6 +17676,12 @@
     "credits": 3.0
   },
   {
+    "code": "FREN182",
+    "title": "Contemporary Fiction in French",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "FREN183",
     "title": "The Novel in France since 1945",
     "campus": "cmc",
@@ -13800,21 +17712,27 @@
     "credits": 3.0
   },
   {
-    "code": "FREN189",
-    "title": "French Across the Curriculum",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "FREN189A",
     "title": "Metro Tales",
     "campus": "po",
     "credits": 3.0
   },
   {
+    "code": "FREN189",
+    "title": "French Across the Curriculum",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "FREN191",
     "title": "Senior Thesis",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "FREN191",
+    "title": "Senior Thesis in French Studies",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -13833,12 +17751,6 @@
     "code": "FREN198",
     "title": "Summer Reading & Research",
     "campus": "po",
-    "credits": 3.0
-  },
-  {
-    "code": "FREN199",
-    "title": "Independent Study in French",
-    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -13866,8 +17778,56 @@
     "credits": 3.0
   },
   {
+    "code": "FREN199",
+    "title": "IS: French Studies",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "FREN199",
+    "title": "Independent St: French Studies",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "FREN199",
+    "title": "Independent Study in French",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "FREN199",
+    "title": "Senior Thesis",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS001",
+    "title": "Life in Latn American Metropolis",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS001",
+    "title": "The Great Transformation",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "FS001",
     "title": "Writing About Animals",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS001",
+    "title": "Youth Culture",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS002",
+    "title": "Not Just Gods and Gladiators",
     "campus": "pz",
     "credits": 3.0
   },
@@ -13878,14 +17838,74 @@
     "credits": 3.0
   },
   {
+    "code": "FS002",
+    "title": "Philosophical Questions",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS002",
+    "title": "Practice of Science",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS003",
+    "title": "Deconstructing Disney",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "FS003",
     "title": "Humor in Art & Visual Culture",
     "campus": "pz",
     "credits": 3.0
   },
   {
+    "code": "FS003",
+    "title": "Nutrition in the Modern World",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS003",
+    "title": "Political Imagination",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS004",
+    "title": "Conspiracy Theories & Populism",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "FS004",
     "title": "Is there a Science of Dreaming?",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS004",
+    "title": "Speculative Feminisms",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS005",
+    "title": "Contesting Science",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS005",
+    "title": "Pseudoscience & Human Thought",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS005",
+    "title": "Selective Science",
     "campus": "pz",
     "credits": 3.0
   },
@@ -13902,8 +17922,38 @@
     "credits": 3.0
   },
   {
+    "code": "FS006",
+    "title": "Higher Education in the US",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS006",
+    "title": "Stereotype Threat!",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS007",
+    "title": "Being__: Stories of Race & Power",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS007",
+    "title": "Impossibilities: Gender & Utopia",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "FS007",
     "title": "Intro to Asian Amer Pop Culture",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS007",
+    "title": "Seeing is Believing",
     "campus": "pz",
     "credits": 3.0
   },
@@ -13914,8 +17964,62 @@
     "credits": 3.0
   },
   {
+    "code": "FS008",
+    "title": "Environmental Documentaries",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS008",
+    "title": "LA: Culture & Environment",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS008",
+    "title": "Unruly Women of World Literature",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS009",
+    "title": "Asians in America",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS009",
+    "title": "Futures Past",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "FS009",
     "title": "The Literate Brain",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS009",
+    "title": "Women & Politcl Change in Africa",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS010",
+    "title": "Experimental Film in Latn Amerca",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS010",
+    "title": "Land(scape) Matters",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS010",
+    "title": "Surfing & Politics:Race & Gender",
     "campus": "pz",
     "credits": 3.0
   },
@@ -13927,7 +18031,31 @@
   },
   {
     "code": "FS011",
+    "title": "Indigenous Cultural Resurgence",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS011",
+    "title": "Observing Color",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS011",
+    "title": "Surfing and the Politics of Race",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS011",
     "title": "Visual Evidence",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS012",
+    "title": "Psychology of Cricket",
     "campus": "pz",
     "credits": 3.0
   },
@@ -13938,14 +18066,74 @@
     "credits": 3.0
   },
   {
+    "code": "FS012",
+    "title": "Unsettling Settlers&Making Space",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS013",
+    "title": "Education, Literacies & Culture",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "FS013",
     "title": "Exploring Natural Disasters",
     "campus": "pz",
     "credits": 3.0
   },
   {
+    "code": "FS013",
+    "title": "Global Intimacies",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS013",
+    "title": "Graffiti and Street Art",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS014",
+    "title": "Gender, Politics, Amercn Culture",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "FS014",
     "title": "La Familia",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS014",
+    "title": "Mindfulness",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS014",
+    "title": "Palestine and Israel",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS015",
+    "title": "Drug Devlp, Policy, & Innovation",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS015",
+    "title": "La Familia",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS015",
+    "title": "Latinx Food,Identity and Resist.",
     "campus": "pz",
     "credits": 3.0
   },
@@ -13962,8 +18150,56 @@
     "credits": 3.0
   },
   {
+    "code": "FS016",
+    "title": "Hist & Pol. Econ. of Wrld Soccer",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS016",
+    "title": "Rich Nations, Poor Nations",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS016",
+    "title": "What is Human?",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS017",
+    "title": "Deconstructing Religion",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "FS017",
     "title": "Love and Loathing in Los Angeles",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS017",
+    "title": "Scandinavian Culture & Society",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS017",
+    "title": "Understanding Change",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS018",
+    "title": "Diversity, Equality & Inequities",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS018",
+    "title": "What's True",
     "campus": "pz",
     "credits": 3.0
   },
@@ -13975,7 +18211,19 @@
   },
   {
     "code": "FS019",
+    "title": "Atheism and Secularity",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS019",
     "title": "Drug Development & Innovation",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "FS019",
+    "title": "Love & Loathing in Los Angeles",
     "campus": "pz",
     "credits": 3.0
   },
@@ -13995,12 +18243,6 @@
     "code": "FWS010",
     "title": "Freshman Writing Seminar",
     "campus": "cmc",
-    "credits": 3.0
-  },
-  {
-    "code": "GEOG179",
-    "title": "Special Topics in Geography",
-    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -14030,6 +18272,12 @@
   {
     "code": "GEOG179E",
     "title": "Geographies of Labor",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "GEOG179",
+    "title": "Special Topics in Geography",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -14143,6 +18391,12 @@
   },
   {
     "code": "GEOL123",
+    "title": "Lab, Neotectonics of So. Calif.",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "GEOL123",
     "title": "Neotectonics of SoCal w/Lab",
     "campus": "po",
     "credits": 3.0
@@ -14150,6 +18404,18 @@
   {
     "code": "GEOL125",
     "title": "Earth History with Laboratory",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "GEOL125",
+    "title": "Lab, Earth History",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "GEOL127",
+    "title": "Lab, Mineralogy",
     "campus": "po",
     "credits": 3.0
   },
@@ -14166,8 +18432,20 @@
     "credits": 3.0
   },
   {
+    "code": "GEOL129",
+    "title": "Lab, Geophysics",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "GEOL130",
     "title": "Carbonates",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "GEOL131",
+    "title": "Lab, Physical Volcanology",
     "campus": "po",
     "credits": 3.0
   },
@@ -14202,8 +18480,26 @@
     "credits": 3.0
   },
   {
+    "code": "GEOL181",
+    "title": "Lab, Igneous/Metamorphic Petrol",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "GEOL183",
+    "title": "Lab, Sedimentology",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "GEOL183",
     "title": "Sedimentology w/Laboratory",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "GEOL185",
+    "title": "Lab, Structural Geology",
     "campus": "po",
     "credits": 3.0
   },
@@ -14216,6 +18512,12 @@
   {
     "code": "GEOL189C",
     "title": "Global Biogeochemical Cycles",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "GEOL189C",
+    "title": "Oceans on a Habitable Planet",
     "campus": "po",
     "credits": 3.0
   },
@@ -14274,6 +18576,18 @@
     "credits": 3.0
   },
   {
+    "code": "GERM001",
+    "title": "Introductory German",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "GERM002",
+    "title": "Elementary German 2",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "GERM002",
     "title": "Introductory German",
     "campus": "sc",
@@ -14316,12 +18630,6 @@
     "credits": 3.0
   },
   {
-    "code": "GERM101",
-    "title": "Introduction to German Culture",
-    "campus": "po",
-    "credits": 3.0
-  },
-  {
     "code": "GERM101B",
     "title": "Vienna Modernism",
     "campus": "sc",
@@ -14334,8 +18642,20 @@
     "credits": 3.0
   },
   {
+    "code": "GERM101",
+    "title": "Introduction to German Culture",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "GERM102",
     "title": "Intro to German Literature",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "GERM103",
+    "title": "A History of German Film",
     "campus": "sc",
     "credits": 3.0
   },
@@ -14418,14 +18738,20 @@
     "credits": 3.0
   },
   {
-    "code": "GERM154",
-    "title": "Great German Fiction",
+    "code": "GERM154F",
+    "title": "Contemporary German Fiction",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "GERM154F",
-    "title": "Contemporary German Fiction",
+    "code": "GERM154",
+    "title": "Great Contemporary Fiction",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "GERM154",
+    "title": "Great German Fiction",
     "campus": "po",
     "credits": 3.0
   },
@@ -14444,6 +18770,12 @@
   {
     "code": "GERM177",
     "title": "The Pact with the Devil",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "GERM189",
+    "title": "German Across the Curriculum",
     "campus": "sc",
     "credits": 3.0
   },
@@ -14472,8 +18804,8 @@
     "credits": 3.0
   },
   {
-    "code": "GERM199",
-    "title": "Independent St: German Studies",
+    "code": "GERM197",
+    "title": "Directed Studies: German",
     "campus": "sc",
     "credits": 3.0
   },
@@ -14487,6 +18819,12 @@
     "code": "GERM199IRPO",
     "title": "German: Independent Research",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "GERM199",
+    "title": "Independent St: German Studies",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -14604,6 +18942,12 @@
     "credits": 3.0
   },
   {
+    "code": "GFS120",
+    "title": "Women and Human Rights Discourse",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "GFS154",
     "title": "Latinas in the Garment Industry",
     "campus": "pz",
@@ -14664,14 +19008,14 @@
     "credits": 3.0
   },
   {
-    "code": "GOVT020",
-    "title": "Introduction American Politics",
+    "code": "GOVT020H",
+    "title": "Intro American Politics (Honors)",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "GOVT020H",
-    "title": "Intro American Politics (Honors)",
+    "code": "GOVT020",
+    "title": "Introduction American Politics",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -14682,14 +19026,14 @@
     "credits": 3.0
   },
   {
-    "code": "GOVT035",
-    "title": "Reading/Resrch:Govt/Polit/Pub Pl",
+    "code": "GOVT030",
+    "title": "Washington Internship",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "GOVT041",
-    "title": "Mock Trial",
+    "code": "GOVT035",
+    "title": "Reading/Resrch:Govt/Polit/Pub Pl",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -14700,8 +19044,20 @@
     "credits": 3.0
   },
   {
+    "code": "GOVT041",
+    "title": "Mock Trial",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "GOVT050",
     "title": "Intro to Public Administration",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "GOVT055",
+    "title": "Empirical Methods",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -14724,13 +19080,25 @@
     "credits": 3.0
   },
   {
-    "code": "GOVT070",
-    "title": "Introduction to Int'l Politics",
+    "code": "GOVT070H",
+    "title": "Intro to Int'l Politics (Honors)",
     "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "GOVT070H",
+    "title": "Introduction to Int'l Politics",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "GOVT070",
+    "title": "Intro to International Politics",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "GOVT070",
     "title": "Introduction to Int'l Politics",
     "campus": "cmc",
     "credits": 3.0
@@ -14767,7 +19135,19 @@
   },
   {
     "code": "GOVT097",
+    "title": "Public Policy Analysis",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "GOVT097",
     "title": "Public Policy Anaylsis",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "GOVT100",
+    "title": "Policy Lab",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -14790,14 +19170,20 @@
     "credits": 3.0
   },
   {
+    "code": "GOVT103E",
+    "title": "Crises in Presidential Leadershp",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "GOVT103",
     "title": "Presidency & the Constitution",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "GOVT103E",
-    "title": "Crises in Presidential Leadershp",
+    "code": "GOVT103",
+    "title": "State, Local Politics, & Policy",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -14844,20 +19230,14 @@
     "credits": 3.0
   },
   {
-    "code": "GOVT111",
-    "title": "Politics and Population",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "GOVT111C",
     "title": "Democratic Education in America",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "GOVT112",
-    "title": "Public Opinion & Ameri Democracy",
+    "code": "GOVT111",
+    "title": "Politics and Population",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -14870,6 +19250,12 @@
   {
     "code": "GOVT112B",
     "title": "Const. Law: Civil Liberties",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "GOVT112",
+    "title": "Public Opinion & Ameri Democracy",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -14916,14 +19302,14 @@
     "credits": 3.0
   },
   {
-    "code": "GOVT120",
-    "title": "Environmental Law & Policy",
+    "code": "GOVT120E",
+    "title": "Environmental Leadership",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "GOVT120E",
-    "title": "Environmental Leadership",
+    "code": "GOVT120",
+    "title": "Environmental Law & Policy",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -14952,12 +19338,6 @@
     "credits": 3.0
   },
   {
-    "code": "GOVT124",
-    "title": "Cases in American Pol Leadership",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "GOVT124A",
     "title": "Cases in American Pol Leadership",
     "campus": "cmc",
@@ -14970,14 +19350,20 @@
     "credits": 3.0
   },
   {
-    "code": "GOVT125",
-    "title": "Readings in Amer Natnl Politics",
+    "code": "GOVT124",
+    "title": "Cases in American Pol Leadership",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "GOVT126",
-    "title": "Policy Analysis",
+    "code": "GOVT125",
+    "title": "President & US Foreign Policy",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "GOVT125",
+    "title": "Readings in Amer Natnl Politics",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -14994,14 +19380,20 @@
     "credits": 3.0
   },
   {
+    "code": "GOVT126",
+    "title": "Policy Analysis",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "GOVT127",
     "title": "Research on Political Process",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "GOVT128",
-    "title": "Ethics and American Democracy",
+    "code": "GOVT127",
+    "title": "Washington Research Project",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -15012,14 +19404,32 @@
     "credits": 3.0
   },
   {
-    "code": "GOVT129",
-    "title": "Ethics, Character & Polit Ldrshp",
+    "code": "GOVT128",
+    "title": "Ethics and American Democracy",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "GOVT128",
+    "title": "Power/Politics/Persuasion in DC",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "GOVT128",
+    "title": "The University Blacklist",
     "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "GOVT129E",
     "title": "PubPol/Leadership in Higher Ed",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "GOVT129",
+    "title": "Ethics, Character & Polit Ldrshp",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -15036,6 +19446,12 @@
     "credits": 3.0
   },
   {
+    "code": "GOVT131",
+    "title": "Pol History of the Middle East",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "GOVT132",
     "title": "Development Aid in Practice",
     "campus": "cmc",
@@ -15048,26 +19464,26 @@
     "credits": 3.0
   },
   {
-    "code": "GOVT133",
-    "title": "India in Asia: Democrcy/Develmt",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "GOVT133E",
     "title": "Dem-Politics/Military in Lat-Am",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "GOVT134",
-    "title": "Mexican Government and Politics",
+    "code": "GOVT133",
+    "title": "India in Asia: Democrcy/Develmt",
     "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "GOVT134E",
     "title": "Democracy & Violence in Mexico",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "GOVT134",
+    "title": "Mexican Government and Politics",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -15084,25 +19500,25 @@
     "credits": 3.0
   },
   {
-    "code": "GOVT136",
-    "title": "Pol of Radical Movements in Amer",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "GOVT136C",
     "title": "Intl Relations of South Asia",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "GOVT137",
-    "title": "Special Topics in Government",
+    "code": "GOVT136",
+    "title": "Pol of Radical Movements in Amer",
     "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "GOVT137B",
+    "title": "Special Topics in Government",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "GOVT137",
     "title": "Special Topics in Government",
     "campus": "cmc",
     "credits": 3.0
@@ -15120,20 +19536,14 @@
     "credits": 3.0
   },
   {
-    "code": "GOVT140",
-    "title": "Intl Politics of Nuclear Weapons",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "GOVT140C",
     "title": "Economy & Society of India",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "GOVT141",
-    "title": "Politic/Craft of Intl Journalism",
+    "code": "GOVT140",
+    "title": "Intl Politics of Nuclear Weapons",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -15150,8 +19560,8 @@
     "credits": 3.0
   },
   {
-    "code": "GOVT142",
-    "title": "Intl Political Feature Writing",
+    "code": "GOVT141",
+    "title": "Politic/Craft of Intl Journalism",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -15180,8 +19590,8 @@
     "credits": 3.0
   },
   {
-    "code": "GOVT143",
-    "title": "Intro Political Journalism Writ",
+    "code": "GOVT142",
+    "title": "Intl Political Feature Writing",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -15192,8 +19602,8 @@
     "credits": 3.0
   },
   {
-    "code": "GOVT144",
-    "title": "Political and Social Movements",
+    "code": "GOVT143",
+    "title": "Intro Political Journalism Writ",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -15211,13 +19621,19 @@
   },
   {
     "code": "GOVT144D",
+    "title": "Democracy and Dictatorship",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "GOVT144D",
     "title": "Democracy in Devel. Countries",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "GOVT145",
-    "title": "Globlizatn & E-Asian Capitalism",
+    "code": "GOVT144",
+    "title": "Political and Social Movements",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -15228,14 +19644,20 @@
     "credits": 3.0
   },
   {
-    "code": "GOVT146",
-    "title": "Chinese Foreign Policy",
+    "code": "GOVT145",
+    "title": "Globlizatn & E-Asian Capitalism",
     "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "GOVT146A",
     "title": "Middle Eastern Politics I",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "GOVT146",
+    "title": "Chinese Foreign Policy",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -15258,26 +19680,26 @@
     "credits": 3.0
   },
   {
-    "code": "GOVT150",
-    "title": "U.S. National Security Policy",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "GOVT150E",
     "title": "Diplomacy/Mil Powr US For Policy",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "GOVT151",
-    "title": "The US, Israel, and the Arabs",
+    "code": "GOVT150",
+    "title": "U.S. National Security Policy",
     "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "GOVT151C",
     "title": "Nations, Nationalism, Mid-East",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "GOVT151",
+    "title": "The US, Israel, and the Arabs",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -15306,12 +19728,6 @@
     "credits": 3.0
   },
   {
-    "code": "GOVT156",
-    "title": "The Korean War",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "GOVT156C",
     "title": "War",
     "campus": "cmc",
@@ -15324,13 +19740,25 @@
     "credits": 3.0
   },
   {
-    "code": "GOVT157S",
-    "title": "Special Topics in Intl Relations",
+    "code": "GOVT156E",
+    "title": "War II: Film",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "GOVT156",
+    "title": "The Korean War",
     "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "GOVT157SBCM",
+    "title": "Special Topics in Intl Relations",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "GOVT157S",
     "title": "Special Topics in Intl Relations",
     "campus": "cmc",
     "credits": 3.0
@@ -15342,14 +19770,14 @@
     "credits": 3.0
   },
   {
-    "code": "GOVT159",
-    "title": "Topics in U.S. Relations w/Asia",
+    "code": "GOVT159I",
+    "title": "Politics of Divided Korea & US",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "GOVT159I",
-    "title": "Politics of Divided Korea & US",
+    "code": "GOVT159",
+    "title": "Topics in U.S. Relations w/Asia",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -15367,6 +19795,12 @@
   },
   {
     "code": "GOVT162",
+    "title": "CS Lewis, Ethics & Politics",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "GOVT162",
     "title": "Comtemporary Political Phil",
     "campus": "cmc",
     "credits": 3.0
@@ -15378,20 +19812,14 @@
     "credits": 3.0
   },
   {
-    "code": "GOVT164",
-    "title": "Political Rhetoric",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "GOVT164E",
     "title": "The Political Novel",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "GOVT165",
-    "title": "Political Philosophy & History",
+    "code": "GOVT164",
+    "title": "Political Rhetoric",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -15402,14 +19830,20 @@
     "credits": 3.0
   },
   {
-    "code": "GOVT166",
-    "title": "Foundations of Political Economy",
+    "code": "GOVT165",
+    "title": "Political Philosophy & History",
     "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "GOVT166C",
     "title": "Politics of the Gig Economy",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "GOVT166",
+    "title": "Foundations of Political Economy",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -15438,14 +19872,14 @@
     "credits": 3.0
   },
   {
-    "code": "GOVT171",
-    "title": "From Theocracy to Democracy",
+    "code": "GOVT171C",
+    "title": "Religion and Liberalism",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "GOVT171C",
-    "title": "Religion and Liberalism",
+    "code": "GOVT171",
+    "title": "From Theocracy to Democracy",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -15456,20 +19890,14 @@
     "credits": 3.0
   },
   {
-    "code": "GOVT173",
-    "title": "Politics of East Europe & Russia",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "GOVT173C",
     "title": "Russian Politics",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "GOVT174",
-    "title": "Topics in Political Philosophy",
+    "code": "GOVT173",
+    "title": "Politics of East Europe & Russia",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -15480,8 +19908,8 @@
     "credits": 3.0
   },
   {
-    "code": "GOVT175",
-    "title": "Politics & Law in American Sport",
+    "code": "GOVT174",
+    "title": "Topics in Political Philosophy",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -15494,6 +19922,12 @@
   {
     "code": "GOVT175E",
     "title": "Elizbthn Politics in Shakespeare",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "GOVT175",
+    "title": "Politics & Law in American Sport",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -15654,6 +20088,12 @@
     "credits": 3.0
   },
   {
+    "code": "GOVT199",
+    "title": "Senior Thesis",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "GOVT999",
     "title": "Honors Seminar",
     "campus": "cmc",
@@ -15679,8 +20119,20 @@
   },
   {
     "code": "GREK033",
+    "title": "Intermediate Classical Greek",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "GREK033",
     "title": "Intermediate Greek",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "GREK044",
+    "title": "Advanced Greek",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -15745,6 +20197,12 @@
   },
   {
     "code": "GRMT131",
+    "title": "Germany Today",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "GRMT131",
     "title": "Topics in Public German Discours",
     "campus": "po",
     "credits": 3.0
@@ -15792,12 +20250,6 @@
     "credits": 3.0
   },
   {
-    "code": "GRMT199",
-    "title": "Indep St:German in Translation",
-    "campus": "sc",
-    "credits": 3.0
-  },
-  {
     "code": "GRMT199DRPO",
     "title": "German St: Directed Readings",
     "campus": "po",
@@ -15810,9 +20262,9 @@
     "credits": 3.0
   },
   {
-    "code": "GWS",
-    "title": "Gender/Women's St: Dir Readings",
-    "campus": "po",
+    "code": "GRMT199",
+    "title": "Indep St:German in Translation",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -15866,6 +20318,12 @@
   {
     "code": "GWS182",
     "title": "Feminist and Queer Materialism",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "GWS183",
+    "title": "Transnational Feminist Theories",
     "campus": "po",
     "credits": 3.0
   },
@@ -15930,6 +20388,24 @@
     "credits": 3.0
   },
   {
+    "code": "GWS",
+    "title": "Gender/Women's St: Dir Readings",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "GWS",
+    "title": "Gender/Women's St: Indep Rsrch",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "GWS",
+    "title": "Gender/Women's St: Rsch Asstship",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "HIST006",
     "title": "Euro Civilizations 1350-present",
     "campus": "po",
@@ -15938,12 +20414,6 @@
   {
     "code": "HIST008",
     "title": "Ancient Heroes and Heroines",
-    "campus": "po",
-    "credits": 3.0
-  },
-  {
-    "code": "HIST010",
-    "title": "The Ancient Mediterranean",
     "campus": "po",
     "credits": 3.0
   },
@@ -15960,9 +20430,27 @@
     "credits": 3.0
   },
   {
+    "code": "HIST010",
+    "title": "The Ancient Mediterranean",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "HIST011",
     "title": "Medieval Mediterranean",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST011",
+    "title": "The World Since 1492",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST012",
+    "title": "History of the Human Sciences",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -15990,8 +20478,32 @@
     "credits": 3.0
   },
   {
+    "code": "HIST017",
+    "title": "Hist/Pol Econ of Nat Resources",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST017",
+    "title": "Intro to Chicanx/Latinx History",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "HIST018",
     "title": "Prisons, Parks & the Legacies of",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST020",
+    "title": "Crisis & Revolution",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST020",
+    "title": "Human Histories:Onset to 1500ish",
     "campus": "pz",
     "credits": 3.0
   },
@@ -16008,8 +20520,20 @@
     "credits": 3.0
   },
   {
+    "code": "HIST021",
+    "title": "The World Since 1492",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "HIST022",
     "title": "History of the Disciplines",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST022",
+    "title": "Middle East/N Africa Since 1500",
     "campus": "pz",
     "credits": 3.0
   },
@@ -16029,6 +20553,12 @@
     "code": "HIST025",
     "title": "All Power to the People",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST025",
+    "title": "US History Before 1877",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -16068,9 +20598,27 @@
     "credits": 3.0
   },
   {
+    "code": "HIST034",
+    "title": "White/Off White:Racial Privilege",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST035",
+    "title": "Hist of Middle East, 600-1500 AD",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "HIST035",
     "title": "The Caribbean:Crucible Modernity",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST036",
+    "title": "History of Modern Middle East",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -16092,15 +20640,15 @@
     "credits": 3.0
   },
   {
-    "code": "HIST040",
-    "title": "History of Africa to 1800",
-    "campus": "po",
-    "credits": 3.0
-  },
-  {
     "code": "HIST040A",
     "title": "Latin America Before 1820",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST040",
+    "title": "History of Africa to 1800",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -16118,6 +20666,12 @@
   {
     "code": "HIST043",
     "title": "Middle East & North Africa 1500",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST043",
+    "title": "Middle East in Modern Times",
     "campus": "po",
     "credits": 3.0
   },
@@ -16152,12 +20706,6 @@
     "credits": 3.0
   },
   {
-    "code": "HIST050",
-    "title": "Journalism in America",
-    "campus": "pz",
-    "credits": 3.0
-  },
-  {
     "code": "HIST050A",
     "title": "African Diaspora in US to 1877",
     "campus": "sc",
@@ -16170,9 +20718,39 @@
     "credits": 3.0
   },
   {
+    "code": "HIST050",
+    "title": "Journalism in America",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST051",
+    "title": "Atomic Bomb in American Culture",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST051",
+    "title": "Iran before & after 2 Revolutns",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST051",
+    "title": "Modern S Asia History/Literature",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "HIST051",
     "title": "Modern South Asian Hist thru Lit",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST052",
+    "title": "Political Islam, 1798- Present",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -16182,9 +20760,21 @@
     "credits": 3.0
   },
   {
+    "code": "HIST052",
+    "title": "The History of Pitzer",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "HIST053",
     "title": "Everyday Life in South Asia",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST053",
+    "title": "Minorities in the Middle East",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -16194,9 +20784,27 @@
     "credits": 3.0
   },
   {
+    "code": "HIST054",
+    "title": "Technology & Medicine",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "HIST055",
     "title": "Middle East: Muhammad-Mongols",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST055",
+    "title": "Popular Protests in Middle East",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST055",
+    "title": "United States History 1620-1877",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -16206,9 +20814,21 @@
     "credits": 3.0
   },
   {
+    "code": "HIST056",
+    "title": "US History: 1877 to Present",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "HIST057",
     "title": "Gunpowder Empires",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST057",
+    "title": "THe US in the Middle East",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -16225,7 +20845,19 @@
   },
   {
     "code": "HIST061",
+    "title": "Native American History",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST061",
     "title": "New Asia: China, Japan, Indones",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST061",
+    "title": "New Asia:Modern China/Japn/Korea",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -16233,6 +20865,12 @@
     "code": "HIST062",
     "title": "China, Japan, Korea in 20th Cent",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST062",
+    "title": "Embodying the Voice of History",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -16260,9 +20898,9 @@
     "credits": 3.0
   },
   {
-    "code": "HIST070",
-    "title": "Europe and the World 1492-1800",
-    "campus": "po",
+    "code": "HIST068",
+    "title": "Prison Autobiography",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -16278,9 +20916,33 @@
     "credits": 3.0
   },
   {
+    "code": "HIST070",
+    "title": "Europe and the World 1492-1800",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST070",
+    "title": "Power, Politics & Mod Art",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "HIST071",
     "title": "Medieval Europe: 800-1300CE",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST071",
+    "title": "Modern Europe Since 1789",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST072",
+    "title": "History of Women in the U.S.",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -16291,13 +20953,31 @@
   },
   {
     "code": "HIST073",
+    "title": "Ordinary People",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST073",
     "title": "Rise of Mod Europe 1750-Present",
     "campus": "cmc",
     "credits": 3.0
   },
   {
+    "code": "HIST073",
+    "title": "The Problem with Profit",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "HIST074",
     "title": "Holiness, Heresy and the Body",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST074",
+    "title": "Queering the Medieval? Holiness",
     "campus": "pz",
     "credits": 3.0
   },
@@ -16314,9 +20994,33 @@
     "credits": 3.0
   },
   {
+    "code": "HIST077",
+    "title": "Great Revolutions in Human Hist",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "HIST078",
     "title": "Museums and Leadership",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST078",
+    "title": "Sex & Gender in Ancient Greece",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST080",
+    "title": "Early America:Invasion-Civil War",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST080",
+    "title": "Revolution and Intervention",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -16327,8 +21031,26 @@
   },
   {
     "code": "HIST081",
+    "title": "Modern America: 1865 to present",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST081",
     "title": "Sci and Tech Early Modern World",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST081",
+    "title": "Science & Tech in Early Modern",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST082",
+    "title": "Modern Science",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -16356,6 +21078,12 @@
     "credits": 3.0
   },
   {
+    "code": "HIST085",
+    "title": "The History of Techno-Utopias",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "HIST089",
     "title": "The Sixties",
     "campus": "pz",
@@ -16365,6 +21093,18 @@
     "code": "HIST090",
     "title": "Early American Capitalism",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST090",
+    "title": "Individual and Society",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST090",
+    "title": "Schooling",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -16393,8 +21133,20 @@
   },
   {
     "code": "HIST095",
+    "title": "Africa from Antiquity to 1500",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST095",
     "title": "Intro to Latin-American Cultures",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST096",
+    "title": "Africa from 1500 to 1870",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -16411,13 +21163,19 @@
   },
   {
     "code": "HIST098",
-    "title": "The Americas: Transnatnl Relatns",
-    "campus": "cmc",
+    "title": "Palestine and Israel",
+    "campus": "pz",
     "credits": 3.0
   },
   {
-    "code": "HIST100",
-    "title": "Freshman Honors Seminar",
+    "code": "HIST098",
+    "title": "State & History:The Israeli Case",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST098",
+    "title": "The Americas: Transnatnl Relatns",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -16470,6 +21228,12 @@
     "credits": 3.0
   },
   {
+    "code": "HIST100",
+    "title": "Freshman Honors Seminar",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "HIST100G",
     "title": "California:Past, Present, Future",
     "campus": "po",
@@ -16494,14 +21258,20 @@
     "credits": 3.0
   },
   {
-    "code": "HIST100N",
-    "title": "Mexico-United States Border",
+    "code": "HIST100NBCH",
+    "title": "US & Latin America Relations",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "HIST100NBCH",
-    "title": "US & Latin America Relations",
+    "code": "HIST100N",
+    "title": "Mexico-U.S. Border (CP)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST100N",
+    "title": "Mexico-United States Border",
     "campus": "po",
     "credits": 3.0
   },
@@ -16542,12 +21312,6 @@
     "credits": 3.0
   },
   {
-    "code": "HIST100W",
-    "title": "The American Political Tradition",
-    "campus": "po",
-    "credits": 3.0
-  },
-  {
     "code": "HIST100WCPO",
     "title": "Early Christian Views of Islam",
     "campus": "po",
@@ -16566,6 +21330,12 @@
     "credits": 3.0
   },
   {
+    "code": "HIST100W",
+    "title": "The American Political Tradition",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "HIST100X",
     "title": "Modern Caribbean Pro-Seminar",
     "campus": "po",
@@ -16574,18 +21344,6 @@
   {
     "code": "HIST100Z",
     "title": "Doing History",
-    "campus": "po",
-    "credits": 3.0
-  },
-  {
-    "code": "HIST101",
-    "title": "Fresh/Soph Honors Seminar",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
-    "code": "HIST101A",
-    "title": "Indian Ocean World",
     "campus": "po",
     "credits": 3.0
   },
@@ -16602,8 +21360,20 @@
     "credits": 3.0
   },
   {
+    "code": "HIST101A",
+    "title": "Indian Ocean World",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "HIST101AKPO",
     "title": "Gunpowder Empires",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST101",
+    "title": "Achilles to Alexander",
     "campus": "po",
     "credits": 3.0
   },
@@ -16632,14 +21402,20 @@
     "credits": 3.0
   },
   {
-    "code": "HIST101H",
-    "title": "American History, 1500-1900",
-    "campus": "po",
+    "code": "HIST101",
+    "title": "Fresh/Soph Honors Seminar",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST101HAPO",
     "title": "History/Biography/Autobiography",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST101H",
+    "title": "American History, 1500-1900",
     "campus": "po",
     "credits": 3.0
   },
@@ -16652,6 +21428,12 @@
   {
     "code": "HIST101J",
     "title": "State,Citizen,Subject Mdrn Japan",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST101K",
+    "title": "Politics of Honor-Ancient Greece",
     "campus": "po",
     "credits": 3.0
   },
@@ -16729,6 +21511,12 @@
   },
   {
     "code": "HIST105",
+    "title": "Achilles to Alexander",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST105",
     "title": "Sex & Gender in Ancient World",
     "campus": "cmc",
     "credits": 3.0
@@ -16746,21 +21534,33 @@
     "credits": 3.0
   },
   {
+    "code": "HIST107",
+    "title": "Dante and the Medieval World",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST108",
+    "title": "Age of Cicero",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "HIST108",
     "title": "Asians in the Americas",
     "campus": "pz",
     "credits": 3.0
   },
   {
-    "code": "HIST109",
-    "title": "First Age of Globalization",
+    "code": "HIST108",
+    "title": "History of Economic Thought",
     "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "HIST110",
-    "title": "Topics in Ancient History",
-    "campus": "cmc",
+    "code": "HIST109",
+    "title": "First Age of Globalization",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -16801,6 +21601,12 @@
   },
   {
     "code": "HIST110K",
+    "title": "Politics of Honor in Anc Greece",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST110K",
     "title": "Topics in Ancient History",
     "campus": "po",
     "credits": 3.0
@@ -16812,15 +21618,33 @@
     "credits": 3.0
   },
   {
+    "code": "HIST110",
+    "title": "Political Movements in East Asia",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "HIST110R",
     "title": "History of the US Right",
     "campus": "po",
     "credits": 3.0
   },
   {
+    "code": "HIST110",
+    "title": "Renaissance Venice",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "HIST110S",
     "title": "Latino Oral Histories (CP)",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST110",
+    "title": "Topics in Ancient History",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -16848,20 +21672,26 @@
     "credits": 3.0
   },
   {
-    "code": "HIST111",
-    "title": "Topics in European History",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "HIST111A",
     "title": "Topics in European History",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "HIST112",
-    "title": "Topics in American History",
+    "code": "HIST111",
+    "title": "Machiavelli",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST111",
+    "title": "Medieval Germany",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST111",
+    "title": "Topics in European History",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -16884,15 +21714,57 @@
     "credits": 3.0
   },
   {
+    "code": "HIST112",
+    "title": "Energy & Humnty, Past, Prsnt, Ft",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST112",
+    "title": "Topics in American History",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST113",
+    "title": "Medieval Spain",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "HIST113",
     "title": "US Environmental History",
     "campus": "cmc",
     "credits": 3.0
   },
   {
+    "code": "HIST113",
+    "title": "Venice and the Islamic East",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST114",
+    "title": "Christian Views of Islam",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "HIST114",
     "title": "Race/Racism in Colonial Americas",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST114",
+    "title": "Renaissance Gender Slaves Heresy",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST115",
+    "title": "State Power Early Modern Europe",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -16903,8 +21775,8 @@
   },
   {
     "code": "HIST116",
-    "title": "Slavery: A World History",
-    "campus": "cmc",
+    "title": "Baroque Civilization",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -16914,9 +21786,51 @@
     "credits": 3.0
   },
   {
+    "code": "HIST116",
+    "title": "Mexican Workers in the US",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST116",
+    "title": "Slavery: A World History",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST116",
+    "title": "Transatlantic/Harlem Renaissance",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST117",
+    "title": "Capitalism in the Renaissance",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST117",
+    "title": "History of Chicano Los Angeles",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "HIST117",
     "title": "Race & Ethnicity in Brazil",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST117",
+    "title": "The Rise of Capitalism",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST118",
+    "title": "Medieval Spain",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -16926,9 +21840,9 @@
     "credits": 3.0
   },
   {
-    "code": "HIST119",
-    "title": "The Sixties",
-    "campus": "cmc",
+    "code": "HIST118",
+    "title": "Teaching US History: Practicum",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -16938,8 +21852,32 @@
     "credits": 3.0
   },
   {
-    "code": "HIST120",
-    "title": "Native American History",
+    "code": "HIST119",
+    "title": "Christian Views of Islam",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST119",
+    "title": "Medieval Thought",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST119",
+    "title": "The Sixties",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST119",
+    "title": "Women and Politics in America",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST120E",
+    "title": "American Suburbia & Its Conseq",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -16947,6 +21885,24 @@
     "code": "HIST120E",
     "title": "The 1920's",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST120",
+    "title": "Native American History",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST121",
+    "title": "African American Music/Protest",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST121",
+    "title": "Early America",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -16968,9 +21924,57 @@
     "credits": 3.0
   },
   {
+    "code": "HIST122",
+    "title": "Enslavement in Early America",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST122",
+    "title": "Religion & the Founding Fathers",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST123",
+    "title": "Africa and the Disciplines",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST123",
+    "title": "Frontiers/Empires in Early Amer.",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "HIST123",
     "title": "History of the American West",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST123",
+    "title": "Philosophy & History of Culture",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST123",
+    "title": "Philosophy/History of Culture",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST124B",
+    "title": "Recent Amer Politics: 1970-Pres",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST124",
+    "title": "Paris & 19C Birth of Modernity",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -16980,8 +21984,14 @@
     "credits": 3.0
   },
   {
-    "code": "HIST124B",
-    "title": "Recent Amer Politics: 1970-Pres",
+    "code": "HIST124",
+    "title": "The U.S. in the Middle East",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST125",
+    "title": "Asian American Hist:1850-Present",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -16992,9 +22002,45 @@
     "credits": 3.0
   },
   {
+    "code": "HIST125",
+    "title": "The American Political Tradition",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "HIST126",
     "title": "American Constitutional History",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST126",
+    "title": "Revolutionary America, 1750-1800",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST126",
+    "title": "Visual Culture in California",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST127",
+    "title": "American Inequality",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST127",
+    "title": "Civil War America",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST127",
+    "title": "Rousseau,Tocqueville,Foucault",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -17010,9 +22056,57 @@
     "credits": 3.0
   },
   {
+    "code": "HIST128",
+    "title": "LGBTQ History of the U.S.",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST128",
+    "title": "Public Art and Controversy",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST128",
+    "title": "U.S. Empire: 1890-present",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST128",
+    "title": "U.S. Gay and Lesbian History",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST129",
+    "title": "Hollywood, War, & Empire",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "HIST129",
     "title": "London & Paris in the 19th Cent.",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST129",
+    "title": "Native Amer Environmental Hist",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST130",
+    "title": "History of Economic Thought",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST130",
+    "title": "Mexico-U.S. Border (CP)",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -17022,9 +22116,9 @@
     "credits": 3.0
   },
   {
-    "code": "HIST131",
-    "title": "The Jewish Experience in America",
-    "campus": "hmc",
+    "code": "HIST130",
+    "title": "Schools of Cultural Criticism",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -17034,9 +22128,27 @@
     "credits": 3.0
   },
   {
-    "code": "HIST132",
-    "title": "Genocide/Hum-Rights 20thC Europe",
+    "code": "HIST131",
+    "title": "Fundamentalism and Rationalism",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST131",
+    "title": "Identity & Culture in Latin Amer",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST131",
+    "title": "Islam & West:Cultural Encounters",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST131",
+    "title": "The Jewish Experience in America",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -17052,14 +22164,32 @@
     "credits": 3.0
   },
   {
-    "code": "HIST132S",
-    "title": "The California Experience",
-    "campus": "hmc",
+    "code": "HIST132",
+    "title": "Genocide/Hum-Rights 20thC Europe",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "HIST133",
-    "title": "Food and American Culture",
+    "code": "HIST132",
+    "title": "Marx in Context",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST132",
+    "title": "Paris, Berlin & London in 1920s",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST132",
+    "title": "Pol Protest & Soc Mov Latin Amer",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST132S",
+    "title": "The California Experience",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -17076,9 +22206,57 @@
     "credits": 3.0
   },
   {
+    "code": "HIST133",
+    "title": "Capital in Context",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST133",
+    "title": "Food and American Culture",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST133",
+    "title": "Freud/Derrida",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST133",
+    "title": "Slavery & Freedom in New World",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "HIST134",
     "title": "Dostoevskii's Russia",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST134",
+    "title": "Drugs & Alcohol in Modern World",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST134",
+    "title": "Empire and Sexuality",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST134",
+    "title": "France/Algeria",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST135",
+    "title": "Destruction of European Jewry",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -17088,14 +22266,38 @@
     "credits": 3.0
   },
   {
-    "code": "HIST136",
-    "title": "The Great War",
+    "code": "HIST135",
+    "title": "Modern Caribbean Pro-Seminar",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST135",
+    "title": "Pseudohistory",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST136",
+    "title": "A History of the Police State",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST136",
+    "title": "Afro-Latin America (CP)",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "HIST136C",
     "title": "Objects of War and Genocide",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST136",
+    "title": "The Great War",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -17107,8 +22309,26 @@
   },
   {
     "code": "HIST138",
+    "title": "Disease, Identity, and Society",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST138",
     "title": "Europe's Total Wars",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST138",
+    "title": "Hist and Sci of Innateness",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST138",
+    "title": "The Global Sixties",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -17125,13 +22345,37 @@
   },
   {
     "code": "HIST140",
-    "title": "Gender/Revoltn Europe 1500-1900",
-    "campus": "cmc",
+    "title": "Atlantic World of Slavery",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "HIST140B",
     "title": "Contemp Latin Amer & Caribbean",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST140",
+    "title": "Contemp Africa/Digital Archives",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST140",
+    "title": "Empire Middle East & South Asia",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST140",
+    "title": "Gender/Revoltn Europe 1500-1900",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST141",
+    "title": "Americas:Race,Labor & Organizing",
     "campus": "sc",
     "credits": 3.0
   },
@@ -17142,8 +22386,14 @@
     "credits": 3.0
   },
   {
+    "code": "HIST141",
+    "title": "Environmental Histories",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "HIST142",
-    "title": "Renaissance & Reformation Euro.",
+    "title": "Cult of Fascism in 20th C Europe",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -17154,9 +22404,21 @@
     "credits": 3.0
   },
   {
-    "code": "HIST143",
-    "title": "Slavery & Freedom in New World",
+    "code": "HIST142",
+    "title": "Renaissance & Reformation Euro.",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST142",
+    "title": "Sea Through Time",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST142",
+    "title": "Slavery & Slave Trading in Afric",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -17178,14 +22440,50 @@
     "credits": 3.0
   },
   {
+    "code": "HIST143",
+    "title": "Cuba/Bolivia/Vzla: Revolution",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "HIST143D",
     "title": "American Revolutions:1760-1830s",
     "campus": "cmc",
     "credits": 3.0
   },
   {
+    "code": "HIST143",
+    "title": "Slavery & Freedom in New World",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "HIST144",
     "title": "Black Intellectual Thought",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST144",
+    "title": "Death and Dying in African Hist",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST144",
+    "title": "Haiti/Colombia/Maroons/Paramilit",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST144",
+    "title": "Reagan's America: the 1980's",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST145",
+    "title": "Afro-Latin America",
     "campus": "po",
     "credits": 3.0
   },
@@ -17202,15 +22500,27 @@
     "credits": 3.0
   },
   {
-    "code": "HIST147",
-    "title": "Mughal India",
-    "campus": "po",
+    "code": "HIST146",
+    "title": "History of Germany 1740-present",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "HIST148",
-    "title": "Women in Euro History: 1450-1815",
-    "campus": "cmc",
+    "code": "HIST146",
+    "title": "Zapatistas/Mayan Rebels",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST147",
+    "title": "American Art and the Civil War",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST147",
+    "title": "Mughal India",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -17226,8 +22536,20 @@
     "credits": 3.0
   },
   {
-    "code": "HIST149",
-    "title": "America in Depression and War",
+    "code": "HIST148",
+    "title": "Gender and Sexuality in Africa",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST148",
+    "title": "Mid East in Europe, Europe in ME",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST148",
+    "title": "Women in Euro History: 1450-1815",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -17238,8 +22560,20 @@
     "credits": 3.0
   },
   {
+    "code": "HIST149",
+    "title": "America in Depression and War",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "HIST149B",
     "title": "Radical Voices",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST149B",
+    "title": "Radical Voices: Women of Lat Am",
     "campus": "sc",
     "credits": 3.0
   },
@@ -17250,14 +22584,56 @@
     "credits": 3.0
   },
   {
+    "code": "HIST149",
+    "title": "Iran and the World",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST150E",
+    "title": "Age of Eliz I and Shakespeare",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST150",
+    "title": "Environmental Hist of Mid-East",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST150",
+    "title": "History and Historiography",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST150",
+    "title": "Journalism in America",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "HIST150",
     "title": "Technology and Medicine",
     "campus": "hmc",
     "credits": 3.0
   },
   {
-    "code": "HIST150E",
-    "title": "Age of Eliz I and Shakespeare",
+    "code": "HIST151",
+    "title": "Atomic Bomb in American Culture",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST151E",
+    "title": "The Making of Modern Britain",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST151",
+    "title": "Jane Austen's Britain",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -17268,15 +22644,33 @@
     "credits": 3.0
   },
   {
-    "code": "HIST151E",
-    "title": "The Making of Modern Britain",
+    "code": "HIST152",
+    "title": "History of Modern Physics",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST152",
+    "title": "Pol & Art in W Europe:1700-1945",
     "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST152",
-    "title": "History of Modern Physics",
-    "campus": "hmc",
+    "title": "The Great Depression 1929-1941",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST153",
+    "title": "Caste & Class in India/S.Asia",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST153",
+    "title": "History of Anthropological Theor",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -17287,8 +22681,20 @@
   },
   {
     "code": "HIST154",
+    "title": "Labor vs Capital in U.S. History",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST154",
     "title": "Makers of Modern India/Pakistan",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST154",
+    "title": "The Old South and Modern Memory",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -17316,9 +22722,15 @@
     "credits": 3.0
   },
   {
+    "code": "HIST158",
+    "title": "US Civil War and Reconstruction",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "HIST159",
-    "title": "Mid East/Central Asia 1200-pres",
-    "campus": "cmc",
+    "title": "Gender+Masculnty:Euro Enlighten",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -17328,8 +22740,50 @@
     "credits": 3.0
   },
   {
+    "code": "HIST159",
+    "title": "Mid East/Central Asia 1200-pres",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST159",
+    "title": "The Great Barbecue: 1865 - 1900",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST159",
+    "title": "Victorian America, 1870-1900",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST160",
+    "title": "EnviroLab Asia:Research/Method",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST160",
+    "title": "Violent Dissent in U.S. Politics",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST160",
+    "title": "Women & Politics in Latin Amer",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "HIST160",
     "title": "Women and Politics in Latin Amer",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST161",
+    "title": "Food/Culture/Power in Asia/Pacif",
     "campus": "po",
     "credits": 3.0
   },
@@ -17341,13 +22795,19 @@
   },
   {
     "code": "HIST162",
-    "title": "The Making of Pre-Modern China",
-    "campus": "cmc",
+    "title": "Borders in East Asia",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "HIST162C",
     "title": "China:Warring States-1st Emperor",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST162",
+    "title": "The Making of Pre-Modern China",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -17358,15 +22818,45 @@
     "credits": 3.0
   },
   {
-    "code": "HIST164",
-    "title": "Mao's China",
-    "campus": "cmc",
+    "code": "HIST163",
+    "title": "Propaganda",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST163",
+    "title": "The Chinese Diaspora",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "HIST164E",
     "title": "China Under Reform: 1978-present",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST164",
+    "title": "Islam in Africa",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST164",
+    "title": "Mao's China",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST165",
+    "title": "20th Century China",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST165",
+    "title": "Baghdad and Constantinople",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -17377,8 +22867,8 @@
   },
   {
     "code": "HIST166",
-    "title": "Late Imperial China 1400-1911",
-    "campus": "cmc",
+    "title": "Cont Issues in Chinese History",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -17388,9 +22878,33 @@
     "credits": 3.0
   },
   {
-    "code": "HIST167",
-    "title": "Gender & History in South Asia",
+    "code": "HIST166IOSC",
+    "title": "Self and Society",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST166",
+    "title": "Late Imperial China 1400-1911",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST166",
+    "title": "Murder & Mayhem Imperial China",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST166",
+    "title": "Political & Cultural Criticism",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST166",
+    "title": "Self and Society",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -17406,9 +22920,39 @@
     "credits": 3.0
   },
   {
+    "code": "HIST167",
+    "title": "Early Modern Japan",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST167",
+    "title": "Gender & History in South Asia",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST167",
+    "title": "US Urban Space, Race and Policy",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST167",
+    "title": "Women and Work in the US",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "HIST168",
     "title": "China & World War II",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST168",
+    "title": "Diaspora, Gender, and Identity",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -17418,9 +22962,15 @@
     "credits": 3.0
   },
   {
-    "code": "HIST169",
-    "title": "Topics in Asian History",
-    "campus": "cmc",
+    "code": "HIST168",
+    "title": "Modern Japan",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST169A",
+    "title": "Freedom+Race:Citizenship+Slavery",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -17442,6 +22992,12 @@
     "credits": 3.0
   },
   {
+    "code": "HIST169",
+    "title": "Topics in Asian History",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "HIST170",
     "title": "Hybrid Identities:Spanish Empire",
     "campus": "pz",
@@ -17449,8 +23005,32 @@
   },
   {
     "code": "HIST171",
+    "title": "American Suburbia & Its Conseq",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST171",
+    "title": "American Suburbia & its Conseq",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST171",
     "title": "Hist African Amer Women in U.S.",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST172",
+    "title": "Empire and Sexuality",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST172",
+    "title": "Enlightenment and Capitalism",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -17466,9 +23046,69 @@
     "credits": 3.0
   },
   {
+    "code": "HIST173",
+    "title": "Religion, Violence & Tolerance",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST173",
+    "title": "The French Revolution",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST174",
+    "title": "Design Activism",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST174",
+    "title": "Holiness, Heresy and the Body",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST174",
+    "title": "The American 1960's",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST174",
+    "title": "The American\" 1960s\"",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST174",
+    "title": "The Russian Revolution",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST174",
+    "title": "The U.S. in the 1960s",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "HIST174",
     "title": "US & Comparative Military System",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST175",
+    "title": "Magic, Heresy & Gender",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST175",
+    "title": "War,Empire+Society US 1898-Pres",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -17484,8 +23124,38 @@
     "credits": 3.0
   },
   {
+    "code": "HIST176",
+    "title": "Early American Families",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST177",
+    "title": "Fords, Flappers+Fundamentalists",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "HIST177",
     "title": "Tpcs in European Social History",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST177",
+    "title": "Winston Churchill",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST178",
+    "title": "Cultures:Conflict,Consenses,Diff",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST178",
+    "title": "Nation, Nationalism, Global ME",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -17496,9 +23166,15 @@
     "credits": 3.0
   },
   {
-    "code": "HIST179",
-    "title": "Special Topics in History",
-    "campus": "hmc",
+    "code": "HIST178",
+    "title": "Women & Gender: Europe 1350-1700",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST178",
+    "title": "World War II",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -17556,14 +23232,62 @@
     "credits": 3.0
   },
   {
+    "code": "HIST179",
+    "title": "Researching the Holocaust",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST179",
+    "title": "Special Topics in History",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST180",
+    "title": "Drugs & Alcohol in Modern World",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST180",
+    "title": "History in a Time of Crisis",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "HIST180",
     "title": "History of European Aristocracy",
     "campus": "cmc",
     "credits": 3.0
   },
   {
+    "code": "HIST180",
+    "title": "Othr Talented Tenth/Af-Am Female",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST180",
+    "title": "Proseminar: What Is History?",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "HIST181",
     "title": "Explorations in Deep Time",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST181",
+    "title": "The Global Sixties",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST182",
+    "title": "Chinese Medicine: Cult,Hist,Body",
     "campus": "pz",
     "credits": 3.0
   },
@@ -17580,9 +23304,27 @@
     "credits": 3.0
   },
   {
+    "code": "HIST183",
+    "title": "The Fall of Rome: End of Empire",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST183",
+    "title": "The World Shakespeare's Monarchs",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "HIST184",
     "title": "Cult of Fascism in 20th C. Europ",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST184",
+    "title": "Global Environmental Histories",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -17592,15 +23334,27 @@
     "credits": 3.0
   },
   {
-    "code": "HIST185",
-    "title": "Making History",
-    "campus": "cmc",
+    "code": "HIST184",
+    "title": "Women and Gender, 1350 - 1700",
+    "campus": "pz",
     "credits": 3.0
   },
   {
-    "code": "HIST186",
-    "title": "Sports Writing",
+    "code": "HIST185",
+    "title": "History and Historiography",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST185",
+    "title": "Information Revolutions x.0&z.0",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST185",
+    "title": "Making History",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -17616,15 +23370,27 @@
     "credits": 3.0
   },
   {
+    "code": "HIST186",
+    "title": "Sports Writing",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "HIST187",
     "title": "After Holocaust, After Gulag",
     "campus": "cmc",
     "credits": 3.0
   },
   {
+    "code": "HIST187",
+    "title": "History & Politcs of World Socc",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "HIST188",
-    "title": "Making Modern Iran & Afghanistan",
-    "campus": "cmc",
+    "title": "Anxiety in the Age of Reason",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -17634,9 +23400,15 @@
     "credits": 3.0
   },
   {
-    "code": "HIST189",
-    "title": "Frankfurt School",
-    "campus": "pz",
+    "code": "HIST188",
+    "title": "Islamic World: Travel/Encounter",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST188",
+    "title": "Making Modern Iran & Afghanistan",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -17670,6 +23442,12 @@
     "credits": 3.0
   },
   {
+    "code": "HIST189",
+    "title": "Frankfurt School",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "HIST189G",
     "title": "History of the Sahara",
     "campus": "po",
@@ -17682,14 +23460,50 @@
     "credits": 3.0
   },
   {
+    "code": "HIST190",
+    "title": "Seminar in History",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST190",
+    "title": "Senior Seminar",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "HIST191",
     "title": "Advanced Topics in Asian History",
     "campus": "cmc",
     "credits": 3.0
   },
   {
+    "code": "HIST191",
+    "title": "Senior Thesis",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST191",
+    "title": "Senior Thesis in History",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "HIST192",
     "title": "Senior Essay",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST192",
+    "title": "Senior Thesis in History",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST193",
+    "title": "Senior Tutorial",
     "campus": "po",
     "credits": 3.0
   },
@@ -17718,9 +23532,15 @@
     "credits": 3.0
   },
   {
+    "code": "HIST196",
+    "title": "Explorations in Deep Time",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "HIST197",
-    "title": "Independent Study: History",
-    "campus": "hmc",
+    "title": "Advanced Topics in World History",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -17732,6 +23552,12 @@
   {
     "code": "HIST197C",
     "title": "History of Economic Thought",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST197D",
+    "title": "Pandemics and Globalized World",
     "campus": "sc",
     "credits": 3.0
   },
@@ -17760,6 +23586,12 @@
     "credits": 3.0
   },
   {
+    "code": "HIST197",
+    "title": "Independent Study: History",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "HIST197R",
     "title": "Topics in Historical Study",
     "campus": "sc",
@@ -17772,14 +23604,26 @@
     "credits": 3.0
   },
   {
-    "code": "HIST198",
-    "title": "Summer Reading & Research",
-    "campus": "po",
+    "code": "HIST197",
+    "title": "Seminar in History",
+    "campus": "pz",
     "credits": 3.0
   },
   {
-    "code": "HIST199",
-    "title": "Indep St Hist & Africana Studies",
+    "code": "HIST197",
+    "title": "Topics in Historical Study",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST198",
+    "title": "Independent Internship",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST198",
+    "title": "Summer Reading & Research",
     "campus": "po",
     "credits": 3.0
   },
@@ -17802,9 +23646,27 @@
     "credits": 3.0
   },
   {
+    "code": "HIST199",
+    "title": "Indep St Hist & Africana Studies",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST199",
+    "title": "Independent Study in History",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "HIST199RAPO",
     "title": "History: Research Assistantship",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST199",
+    "title": "Senior Thesis",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -17874,6 +23736,12 @@
     "credits": 3.0
   },
   {
+    "code": "HMSC123",
+    "title": "Philosophy/History of Culture",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "HMSC130",
     "title": "Schools of Cultural Criticism",
     "campus": "sc",
@@ -17886,6 +23754,12 @@
     "credits": 3.0
   },
   {
+    "code": "HMSC133",
+    "title": "Modernity and the Unconscious",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "HMSC134",
     "title": "Found Postcolonial Theory",
     "campus": "sc",
@@ -17894,6 +23768,12 @@
   {
     "code": "HMSC135",
     "title": "Language, Culture and Society",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HMSC136",
+    "title": "Critical Theory & Modern Culture",
     "campus": "sc",
     "credits": 3.0
   },
@@ -18018,20 +23898,32 @@
     "credits": 3.0
   },
   {
-    "code": "HSA179",
-    "title": "Special Topics: Hum/SocSci/Arts",
-    "campus": "hmc",
-    "credits": 3.0
-  },
-  {
     "code": "HSA179A",
     "title": "Soc/EthIssues:CommunityEngagemnt",
     "campus": "hmc",
     "credits": 3.0
   },
   {
+    "code": "HSA179",
+    "title": "Special Topics: Hum/SocSci/Arts",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HSA179",
+    "title": "Writing Pedagogies: Research,",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "HSA197",
     "title": "IndepStudy:Humanities/SocSci/Art",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HSA197",
+    "title": "Independent Study",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -18216,13 +24108,13 @@
     "credits": 3.0
   },
   {
-    "code": "HUMCONC",
+    "code": "HUMCONC1",
     "title": "Humanities Conc",
     "campus": "hmc",
     "credits": 3.0
   },
   {
-    "code": "HUMCONC1",
+    "code": "HUMCONC",
     "title": "Humanities Conc",
     "campus": "hmc",
     "credits": 3.0
@@ -18240,12 +24132,6 @@
     "credits": 3.0
   },
   {
-    "code": "ID",
-    "title": "Sr Exper Thes:Dual Sci Majors",
-    "campus": "sc",
-    "credits": 3.0
-  },
-  {
     "code": "ID001",
     "title": "Critical Inquiry Seminar",
     "campus": "po",
@@ -18255,6 +24141,12 @@
     "code": "ID026",
     "title": "Intro to Women's Studies",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ID026",
+    "title": "Introduction to Women's Studies",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -18289,19 +24181,25 @@
   },
   {
     "code": "ID048",
-    "title": "SocialJustice&Equity/STEM&Beyond",
+    "title": "Social Justice&Equity/STEM&Beyon",
     "campus": "hmc",
     "credits": 3.0
   },
   {
-    "code": "ID049",
-    "title": "Special Topics:Interdisciplinary",
+    "code": "ID048",
+    "title": "SocialJustice&Equity/STEM&Beyond",
     "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "ID049A",
     "title": "Mudd 101: Making the Most of HMC",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ID049",
+    "title": "Special Topics:Interdisciplinary",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -18327,6 +24225,18 @@
     "code": "ID099",
     "title": "Civic Leadership, Resp, & Involv",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ID099",
+    "title": "Ind Std: Interdisciplinary Stds",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ID099",
+    "title": "MMUF Seminar",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -18391,6 +24301,12 @@
   },
   {
     "code": "ID110",
+    "title": "Major Course REQ Met",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ID110",
     "title": "Science & Alternative Medicine",
     "campus": "cmc",
     "credits": 3.0
@@ -18399,6 +24315,12 @@
     "code": "ID111",
     "title": "Lessons Learned on Study Abroad",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ID111",
+    "title": "Minor REQ met",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -18417,6 +24339,12 @@
     "code": "ID121",
     "title": "Black Politics in the US",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ID121",
+    "title": "Strategies:Solving Soc Problems",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -18450,15 +24378,15 @@
     "credits": 3.0
   },
   {
-    "code": "ID180",
-    "title": "Interdisciplinary Practicum",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "ID180C",
     "title": "Climate Sci and Human Behavior",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ID180",
+    "title": "Interdisciplinary Practicum",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -18474,12 +24402,6 @@
     "credits": 3.0
   },
   {
-    "code": "ID191",
-    "title": "Senior Thesis Interdisc Majors",
-    "campus": "sc",
-    "credits": 3.0
-  },
-  {
     "code": "ID191D",
     "title": "Senior Thesis for Dual Majors",
     "campus": "sc",
@@ -18488,6 +24410,12 @@
   {
     "code": "ID191S",
     "title": "Sr Thesis:Self-Designed Majors",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ID191",
+    "title": "Senior Thesis Interdisc Majors",
     "campus": "sc",
     "credits": 3.0
   },
@@ -18504,13 +24432,13 @@
     "credits": 3.0
   },
   {
-    "code": "ID196",
+    "code": "ID196A",
     "title": "Gould Center Seminar",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "ID196A",
+    "code": "ID196",
     "title": "Gould Center Seminar",
     "campus": "cmc",
     "credits": 3.0
@@ -18523,8 +24451,80 @@
   },
   {
     "code": "ID199",
+    "title": "Ind Std: Interdisciplinary Stds",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ID199",
+    "title": "Indep St: Interdisciplinary St",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ID199",
     "title": "Independent Study",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "ID",
+    "title": "Community Partnerships",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ID",
+    "title": "Independent Study: Persian 1",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ID",
+    "title": "Independent Study: Persian 2",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ID",
+    "title": "Independent Study: Persian 3",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ID",
+    "title": "Independent Study: Persian 4",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ID",
+    "title": "Independent Study: Swahili 1",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ID",
+    "title": "Independent Study: Swahili 3",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ID",
+    "title": "Independent Study:Swahili 2",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ID",
+    "title": "Second Language Acquisition",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ID",
+    "title": "Sr Exper Thes:Dual Sci Majors",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -18541,13 +24541,19 @@
   },
   {
     "code": "IE179",
-    "title": "Special Topics: Integrative Stds",
+    "title": "Approaches to Leadership",
     "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "IE179D",
     "title": "Social Justice&Equity/STEM Educ",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "IE179",
+    "title": "Special Topics: Integrative Stds",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -18678,12 +24684,6 @@
     "credits": 3.0
   },
   {
-    "code": "IIS109",
-    "title": "Chinese Phil, Culture & Trad Med",
-    "campus": "pz",
-    "credits": 3.0
-  },
-  {
     "code": "IIS109B",
     "title": "Chinese Phil, Culture & Trad Med",
     "campus": "pz",
@@ -18691,6 +24691,12 @@
   },
   {
     "code": "IIS109C",
+    "title": "Chinese Phil, Culture & Trad Med",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "IIS109",
     "title": "Chinese Phil, Culture & Trad Med",
     "campus": "pz",
     "credits": 3.0
@@ -18704,6 +24710,12 @@
   {
     "code": "IIS113",
     "title": "Science Politics & Alt Medicine",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "IIS113",
+    "title": "Science, Politics & Alt Medicine",
     "campus": "pz",
     "credits": 3.0
   },
@@ -18734,6 +24746,12 @@
   {
     "code": "IIS122",
     "title": "Contemp Pol & Soc Movts:3rd Wrld",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "IIS122",
+    "title": "Socl & Pol Movmnts in Third Wrld",
     "campus": "pz",
     "credits": 3.0
   },
@@ -18883,6 +24901,12 @@
   },
   {
     "code": "INT099",
+    "title": "Internship",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "INT099",
     "title": "Internship (Non-Credit)",
     "campus": "cmc",
     "credits": 3.0
@@ -18890,12 +24914,6 @@
   {
     "code": "INT198",
     "title": "Internship: CMC Sponsored",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
-    "code": "INT199",
-    "title": "Internship",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -18924,6 +24942,12 @@
     "credits": 3.0
   },
   {
+    "code": "INT199",
+    "title": "Internship",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "INT199J",
     "title": "Internship: Non-Profit",
     "campus": "cmc",
@@ -18939,12 +24963,6 @@
     "code": "IPSOMC",
     "title": "Off Campus IPS Course",
     "campus": "hmc",
-    "credits": 3.0
-  },
-  {
-    "code": "IR",
-    "title": "Intl Relations:Directed Readings",
-    "campus": "po",
     "credits": 3.0
   },
   {
@@ -18986,6 +25004,24 @@
   {
     "code": "IR191",
     "title": "Senior Thesis",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "IR",
+    "title": "Intl Relations: Ind Research",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "IR",
+    "title": "Intl Relations: Rsrch Asstship",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "IR",
+    "title": "Intl Relations:Directed Readings",
     "campus": "po",
     "credits": 3.0
   },
@@ -19057,6 +25093,12 @@
   },
   {
     "code": "IST302",
+    "title": "Databases",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "IST302",
     "title": "Databases and Big Data",
     "campus": "cgu",
     "credits": 3.0
@@ -19076,6 +25118,12 @@
   {
     "code": "IST305",
     "title": "Managemnt of IT in Complex Times",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "IST311",
+    "title": "Mobile Application Development",
     "campus": "cgu",
     "credits": 3.0
   },
@@ -19242,6 +25290,12 @@
     "credits": 3.0
   },
   {
+    "code": "ITAL133",
+    "title": "Contemporary Italy",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ITAL134",
     "title": "20C Italian Women's Literature",
     "campus": "sc",
@@ -19268,6 +25322,12 @@
   {
     "code": "ITAL140",
     "title": "Italian Cinema",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "ITAL142",
+    "title": "Italian Cinema & Literature",
     "campus": "sc",
     "credits": 3.0
   },
@@ -19308,14 +25368,14 @@
     "credits": 3.0
   },
   {
-    "code": "ITAL197",
-    "title": "Special Topics in Italian",
+    "code": "ITAL197A",
+    "title": "The Works of Italo Calvino",
     "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "ITAL197A",
-    "title": "The Works of Italo Calvino",
+    "code": "ITAL197",
+    "title": "Special Topics in Italian",
     "campus": "sc",
     "credits": 3.0
   },
@@ -19410,8 +25470,8 @@
     "credits": 3.0
   },
   {
-    "code": "JAPN125",
-    "title": "Readings in Modern Japanese Lit",
+    "code": "JAPN125H",
+    "title": "Continuing Japanese",
     "campus": "po",
     "credits": 3.0
   },
@@ -19422,14 +25482,20 @@
     "credits": 3.0
   },
   {
-    "code": "JAPN126",
-    "title": "Japanese through Current Media",
+    "code": "JAPN125",
+    "title": "Readings in Modern Japanese Lit",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "JAPN126H",
     "title": "Japanese Through Current Media",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "JAPN126",
+    "title": "Japanese through Current Media",
     "campus": "po",
     "credits": 3.0
   },
@@ -19458,12 +25524,6 @@
     "credits": 3.0
   },
   {
-    "code": "JAPN192",
-    "title": "Senior Research Paper",
-    "campus": "po",
-    "credits": 3.0
-  },
-  {
     "code": "JAPN192A",
     "title": "Senior Project",
     "campus": "po",
@@ -19472,6 +25532,12 @@
   {
     "code": "JAPN192B",
     "title": "Senior Project",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "JAPN192",
+    "title": "Senior Research Paper",
     "campus": "po",
     "credits": 3.0
   },
@@ -19525,6 +25591,12 @@
   },
   {
     "code": "JPNT174",
+    "title": "(Post-) Modrn Jpn Lit & Cinema",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "JPNT174",
     "title": "Modern Japanese Literature",
     "campus": "po",
     "credits": 3.0
@@ -19568,6 +25640,12 @@
   {
     "code": "JWST198",
     "title": "Independent Internship",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "JWST199",
+    "title": "Independent St: Jewish Studies",
     "campus": "sc",
     "credits": 3.0
   },
@@ -19674,15 +25752,15 @@
     "credits": 3.0
   },
   {
-    "code": "LAST193",
-    "title": "Senior Comprehensive Exam",
-    "campus": "po",
+    "code": "LAST191",
+    "title": "Senior Thesis:Latin American St",
+    "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "LAST199",
-    "title": "Independ St: Latin American St",
-    "campus": "sc",
+    "code": "LAST193",
+    "title": "Senior Comprehensive Exam",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -19695,6 +25773,12 @@
     "code": "LAST199IRPO",
     "title": "Latin Amer St: Indep Research",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "LAST199",
+    "title": "Independ St: Latin American St",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -19717,6 +25801,12 @@
   },
   {
     "code": "LATN022",
+    "title": "Advanced Introductory Latin",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "LATN022",
     "title": "Introductory Latin Accelerated",
     "campus": "po",
     "credits": 3.0
@@ -19731,6 +25821,12 @@
     "code": "LATN044",
     "title": "Advanced Latin Readings",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "LATN044",
+    "title": "Advanced Latin Readings: Drama",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -19824,12 +25920,6 @@
     "credits": 3.0
   },
   {
-    "code": "LEAD179",
-    "title": "Special Topics in Leadership",
-    "campus": "hmc",
-    "credits": 3.0
-  },
-  {
     "code": "LEAD179A",
     "title": "Interpersonal Dynamics",
     "campus": "hmc",
@@ -19848,15 +25938,15 @@
     "credits": 3.0
   },
   {
-    "code": "LEAD197",
-    "title": "Indep Study: Leadership Studies",
+    "code": "LEAD179",
+    "title": "Special Topics in Leadership",
     "campus": "hmc",
     "credits": 3.0
   },
   {
-    "code": "LGCS",
-    "title": "Independent Study",
-    "campus": "pz",
+    "code": "LEAD197",
+    "title": "Indep Study: Leadership Studies",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -19957,6 +26047,12 @@
   },
   {
     "code": "LGCS118",
+    "title": "Morphosyntactic Diversity",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "LGCS118",
     "title": "Principles of Human Interaction",
     "campus": "po",
     "credits": 3.0
@@ -20034,6 +26130,12 @@
     "credits": 3.0
   },
   {
+    "code": "LGCS166",
+    "title": "Tpcs in Soclng:Ethnicity in Mdia",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "LGCS181",
     "title": "Topics in Quantitative Ling",
     "campus": "po",
@@ -20054,12 +26156,6 @@
   {
     "code": "LGCS184",
     "title": "Topics in Phonology",
-    "campus": "po",
-    "credits": 3.0
-  },
-  {
-    "code": "LGCS185",
-    "title": "Topics in Cognitive Science",
     "campus": "po",
     "credits": 3.0
   },
@@ -20088,6 +26184,12 @@
     "credits": 3.0
   },
   {
+    "code": "LGCS185",
+    "title": "Topics in Cognitive Science",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "LGCS187A",
     "title": "Tutorial in Ling & Cognitive Sci",
     "campus": "po",
@@ -20107,7 +26209,19 @@
   },
   {
     "code": "LGCS190",
+    "title": "Senior Seminar in Linguistics",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "LGCS190",
     "title": "Senior Study in Ling & Cogn Sci",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "LGCS191",
+    "title": "Senior Thesis",
     "campus": "pz",
     "credits": 3.0
   },
@@ -20115,6 +26229,12 @@
     "code": "LGCS191",
     "title": "Senior Thesis in Ling & Cog Sci",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "LGCS191",
+    "title": "Senior Thesis:Ling Cognitive Sci",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -20127,6 +26247,12 @@
     "code": "LGCS197",
     "title": "Indep Study:Linguistics/CognSci",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "LGCS198",
+    "title": "Independent Internship",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -20155,6 +26281,12 @@
   },
   {
     "code": "LGCS999",
+    "title": "Independent Study",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "LGCS",
     "title": "Independent Study",
     "campus": "pz",
     "credits": 3.0
@@ -20197,7 +26329,7 @@
   },
   {
     "code": "LIT",
-    "title": "U.S. Latinx Literature",
+    "title": "#MeToo Shakespeare",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -20210,6 +26342,12 @@
   {
     "code": "LIT030",
     "title": "Expository Writing",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "LIT030",
+    "title": "Introduction to Video Art",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -20448,6 +26586,12 @@
     "credits": 3.0
   },
   {
+    "code": "LIT088",
+    "title": "War and Peace",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "LIT089",
     "title": "Poetry of English Enlightenment",
     "campus": "cmc",
@@ -20508,12 +26652,6 @@
     "credits": 3.0
   },
   {
-    "code": "LIT099",
-    "title": "Special Topics in Literature",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "LIT099A",
     "title": "Special Topics in Literature",
     "campus": "cmc",
@@ -20544,6 +26682,12 @@
     "credits": 3.0
   },
   {
+    "code": "LIT099",
+    "title": "Special Topics in Literature",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "LIT100",
     "title": "Literary Theory Since Plato",
     "campus": "cmc",
@@ -20563,6 +26707,18 @@
   },
   {
     "code": "LIT103",
+    "title": "Modern Poetry",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "LIT103",
+    "title": "The Idea of Poetry",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "LIT103",
     "title": "Third Cinema",
     "campus": "hmc",
     "credits": 3.0
@@ -20571,6 +26727,18 @@
     "code": "LIT104",
     "title": "Intro Middle English Literature",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "LIT104",
+    "title": "The Tragedies of Sophocles",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "LIT105",
+    "title": "Gender & Family in Medieval Lit",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -20586,14 +26754,20 @@
     "credits": 3.0
   },
   {
+    "code": "LIT107B",
+    "title": "Medieval Drama",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "LIT107",
     "title": "Creative Writing",
     "campus": "hmc",
     "credits": 3.0
   },
   {
-    "code": "LIT107B",
-    "title": "Medieval Drama",
+    "code": "LIT107",
+    "title": "Modern Drama",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -20613,6 +26787,18 @@
     "code": "LIT110",
     "title": "Performing Shakespeare",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "LIT110",
+    "title": "Shakespeare",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "LIT110",
+    "title": "The Age of Chivalry",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -20652,12 +26838,6 @@
     "credits": 3.0
   },
   {
-    "code": "LIT117",
-    "title": "Lit of Late Medieval England",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "LIT117A",
     "title": "Dickens, Hardy, & Victorian Age",
     "campus": "hmc",
@@ -20667,6 +26847,12 @@
     "code": "LIT117B",
     "title": "Dickens, Hardy, & Victorian Age",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "LIT117",
+    "title": "Lit of Late Medieval England",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -20826,15 +27012,33 @@
     "credits": 3.0
   },
   {
+    "code": "LIT144",
+    "title": "W.B. Yeats",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "LIT145",
     "title": "Third World Women Writers",
     "campus": "hmc",
     "credits": 3.0
   },
   {
+    "code": "LIT145",
+    "title": "Wilde & Co.",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "LIT146",
     "title": "20th Century South African Lit",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "LIT147",
+    "title": "The Word and the Garden",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -20868,6 +27072,12 @@
     "credits": 3.0
   },
   {
+    "code": "LIT155",
+    "title": "Writing Nature",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "LIT156",
     "title": "Translation/Foreignness of Lang",
     "campus": "hmc",
@@ -20892,6 +27102,12 @@
     "credits": 3.0
   },
   {
+    "code": "LIT160",
+    "title": "Science & Faith in Modern Lit",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "LIT161",
     "title": "Leadership & Diversity in Lit",
     "campus": "cmc",
@@ -20900,6 +27116,18 @@
   {
     "code": "LIT162",
     "title": "African Literature",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "LIT162",
+    "title": "Literature & the Visual Arts",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "LIT163",
+    "title": "Leadership in Literature & Film",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -20918,6 +27146,12 @@
   {
     "code": "LIT165",
     "title": "Caribbean Women Writers",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "LIT165",
+    "title": "Nietzsche, Marx & Freud",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -20973,12 +27207,6 @@
     "code": "LIT177",
     "title": "The Art of Oratory",
     "campus": "cmc",
-    "credits": 3.0
-  },
-  {
-    "code": "LIT179",
-    "title": "Special Topics in Literature",
-    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -21090,6 +27318,12 @@
     "credits": 3.0
   },
   {
+    "code": "LIT179",
+    "title": "Special Topics in Literature",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "LIT179T",
     "title": "The Double",
     "campus": "hmc",
@@ -21180,6 +27414,30 @@
     "credits": 3.0
   },
   {
+    "code": "LIT",
+    "title": "Pop Up Shakespeare",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "LIT",
+    "title": "Sci-Fi, Horror, & Other Tales",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "LIT",
+    "title": "Special Topics in Literature",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "LIT",
+    "title": "U.S. Latinx Literature",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "LRE3047",
     "title": "Mediation & Negotiation",
     "campus": "cgu",
@@ -21201,6 +27459,12 @@
     "code": "LSF3028",
     "title": "Mthds Soc Healing/Reconciliation",
     "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH001",
+    "title": "Math Philosophy & the Real World",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -21234,6 +27498,12 @@
     "credits": 3.0
   },
   {
+    "code": "MATH008",
+    "title": "Philosophy of Mathematics",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "MATH009",
     "title": "Math, Art, and the Environment",
     "campus": "pz",
@@ -21248,12 +27518,6 @@
   {
     "code": "MATH010G",
     "title": "Mathematics in Many Cultures",
-    "campus": "pz",
-    "credits": 3.0
-  },
-  {
-    "code": "MATH010H",
-    "title": "Topology",
     "campus": "pz",
     "credits": 3.0
   },
@@ -21276,6 +27540,12 @@
     "credits": 3.0
   },
   {
+    "code": "MATH010H",
+    "title": "Topology",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "MATH010V",
     "title": "Math Mystery Tour",
     "campus": "pz",
@@ -21288,14 +27558,14 @@
     "credits": 3.0
   },
   {
-    "code": "MATH011",
-    "title": "Theories of Electoral Systems",
+    "code": "MATH011B",
+    "title": "Doodling in Math Class",
     "campus": "pz",
     "credits": 3.0
   },
   {
-    "code": "MATH011B",
-    "title": "Doodling in Math Class",
+    "code": "MATH011",
+    "title": "Theories of Electoral Systems",
     "campus": "pz",
     "credits": 3.0
   },
@@ -21303,6 +27573,18 @@
     "code": "MATH015",
     "title": "Application & Art of Calculus",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH015",
+    "title": "Journeys in Mathematics",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH015",
+    "title": "Math for Teachers I: Number&Oper",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -21349,14 +27631,14 @@
   },
   {
     "code": "MATH029",
-    "title": "Late Transcendental Calculus",
-    "campus": "hmc",
+    "title": "Calculus & Applied Math",
+    "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "MATH030",
-    "title": "Calculus I",
-    "campus": "cmc",
+    "code": "MATH029",
+    "title": "Late Transcendental Calculus",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -21372,20 +27654,26 @@
     "credits": 3.0
   },
   {
+    "code": "MATH030",
+    "title": "Calculus I",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "MATH030G",
     "title": "Calculus",
     "campus": "hmc",
     "credits": 3.0
   },
   {
-    "code": "MATH031",
-    "title": "Calculus II",
+    "code": "MATH031A",
+    "title": "Calculus II-A",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "MATH031A",
-    "title": "Calculus II-A",
+    "code": "MATH031",
+    "title": "Calculus II",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -21398,6 +27686,12 @@
   {
     "code": "MATH031S",
     "title": "Calc II w/Apps to Life Sciences",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH031S",
+    "title": "Calc II w/Apps to Science",
     "campus": "po",
     "credits": 3.0
   },
@@ -21420,9 +27714,27 @@
     "credits": 3.0
   },
   {
+    "code": "MATH032S",
+    "title": "Calc III w/Apps to the Sciences",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH035",
+    "title": "Foundations of Pure Mathematics",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "MATH035",
     "title": "Probability and Statistics",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH035",
+    "title": "Subcalculus Seminar",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -21462,12 +27774,6 @@
     "credits": 3.0
   },
   {
-    "code": "MATH049",
-    "title": "First-Year Special Topics: Math",
-    "campus": "hmc",
-    "credits": 3.0
-  },
-  {
     "code": "MATH049A",
     "title": "Fluidity:Intersection Math & Art",
     "campus": "hmc",
@@ -21492,14 +27798,14 @@
     "credits": 3.0
   },
   {
-    "code": "MATH050",
-    "title": "Finite Mathematics",
-    "campus": "cmc",
+    "code": "MATH049",
+    "title": "First-Year Special Topics: Math",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
-    "code": "MATH052",
-    "title": "Introduction to Statistics",
+    "code": "MATH050",
+    "title": "Finite Mathematics",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -21510,9 +27816,9 @@
     "credits": 3.0
   },
   {
-    "code": "MATH055",
-    "title": "Discrete Mathematics",
-    "campus": "hmc",
+    "code": "MATH052",
+    "title": "Introduction to Statistics",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -21522,14 +27828,14 @@
     "credits": 3.0
   },
   {
-    "code": "MATH057",
-    "title": "Thinking with Data",
-    "campus": "po",
+    "code": "MATH055",
+    "title": "Discrete Mathematics",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
-    "code": "MATH058",
-    "title": "Introduction to Statistics w/Lab",
+    "code": "MATH057",
+    "title": "Thinking with Data",
     "campus": "po",
     "credits": 3.0
   },
@@ -21546,15 +27852,45 @@
     "credits": 3.0
   },
   {
-    "code": "MATH060",
-    "title": "Multivariable Calculus",
-    "campus": "hmc",
+    "code": "MATH058",
+    "title": "Intro to Statistics w/Lab",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH058",
+    "title": "Intro to Statistics w/Lab (CP)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH058",
+    "title": "Introduction to Statistics w/Lab",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH058",
+    "title": "Lab, Intro to Statistics",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "MATH060C",
     "title": "Linear Algebra with Computing",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH060",
+    "title": "Linear Algebra",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH060",
+    "title": "Multivariable Calculus",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -21637,6 +27973,12 @@
   },
   {
     "code": "MATH100",
+    "title": "Intro to Advanced Mathematics",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH100",
     "title": "Introduction to Methods of Proof",
     "campus": "pz",
     "credits": 3.0
@@ -21649,7 +27991,19 @@
   },
   {
     "code": "MATH102",
+    "title": "Differential Equations+Modeling",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH102",
     "title": "Differential Equations/Modeling",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH103",
+    "title": "Combinatorial Mathematics",
     "campus": "po",
     "credits": 3.0
   },
@@ -21657,6 +28011,12 @@
     "code": "MATH103",
     "title": "Combinatorics",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH103",
+    "title": "Lab, Combinatorial Math",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -21678,12 +28038,6 @@
     "credits": 3.0
   },
   {
-    "code": "MATH108",
-    "title": "History of Mathematics",
-    "campus": "pz",
-    "credits": 3.0
-  },
-  {
     "code": "MATH108A",
     "title": "History of Math Before 1636",
     "campus": "pz",
@@ -21692,6 +28046,12 @@
   {
     "code": "MATH108B",
     "title": "History of Mathematcs since 1636",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH108",
+    "title": "History of Mathematics",
     "campus": "pz",
     "credits": 3.0
   },
@@ -21721,6 +28081,12 @@
   },
   {
     "code": "MATH112",
+    "title": "Discrete Dynamical Sys & Chaos",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH112",
     "title": "Intro Dynamical Systems & Chaos",
     "campus": "cmc",
     "credits": 3.0
@@ -21744,15 +28110,45 @@
     "credits": 3.0
   },
   {
+    "code": "MATH119",
+    "title": "Mathematics Research Circle",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH131",
+    "title": "Math Analysis I",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "MATH131",
     "title": "Mathematical Analysis I",
     "campus": "hmc",
     "credits": 3.0
   },
   {
+    "code": "MATH131",
+    "title": "Principles of Real Analysis I",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH132",
+    "title": "Math Analysis II",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "MATH132",
     "title": "Mathematical Analysis II",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH132",
+    "title": "Principles of Real Analysis II",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -21774,6 +28170,12 @@
     "credits": 3.0
   },
   {
+    "code": "MATH135",
+    "title": "Functions of a Complex Variable",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "MATH136",
     "title": "Cmplx Variables/Integral Trnsfrm",
     "campus": "hmc",
@@ -21786,9 +28188,39 @@
     "credits": 3.0
   },
   {
+    "code": "MATH137",
+    "title": "Real & Functional Analysis I",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH137",
+    "title": "Real Analysis I",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "MATH138",
     "title": "Graduate Analysis II",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH138",
+    "title": "Real & Functional Analysis II",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH138",
+    "title": "Real Analysis II",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH138",
+    "title": "Real and Functional Analysis II",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -21828,15 +28260,27 @@
     "credits": 3.0
   },
   {
-    "code": "MATH145",
-    "title": "Topics in Geometry and Topology",
-    "campus": "po",
+    "code": "MATH144",
+    "title": "Classical and Modern Geometries",
+    "campus": "sc",
     "credits": 3.0
   },
   {
     "code": "MATH145B",
     "title": "Geometric Modeling",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH145",
+    "title": "Topics Topology:Calc Variations",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH145",
+    "title": "Topics in Geometry and Topology",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -21858,12 +28302,6 @@
     "credits": 3.0
   },
   {
-    "code": "MATH149",
-    "title": "Discrete Geometry",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "MATH149A",
     "title": "Algebraic Topology",
     "campus": "cmc",
@@ -21876,9 +28314,27 @@
     "credits": 3.0
   },
   {
+    "code": "MATH149",
+    "title": "Discrete Geometry",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH150",
+    "title": "Methods in Biostatistics",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "MATH150",
     "title": "Stat Method Clinical Trials Data",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH151G",
+    "title": "Probability",
+    "campus": "cgu",
     "credits": 3.0
   },
   {
@@ -21888,9 +28344,9 @@
     "credits": 3.0
   },
   {
-    "code": "MATH151G",
-    "title": "Probability",
-    "campus": "cgu",
+    "code": "MATH152",
+    "title": "Statistical Inference",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -21918,15 +28374,15 @@
     "credits": 3.0
   },
   {
-    "code": "MATH156",
-    "title": "Stochastic Processes",
-    "campus": "hmc",
-    "credits": 3.0
-  },
-  {
     "code": "MATH156G",
     "title": "Stochastic Processes",
     "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH156",
+    "title": "Stochastic Processes",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -21936,9 +28392,27 @@
     "credits": 3.0
   },
   {
+    "code": "MATH157",
+    "title": "Stochastic Calculus for Finance",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH158",
+    "title": "Applied Statistics",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "MATH158",
     "title": "Statistical Linear Models",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH159",
+    "title": "Advanced Topics in Statistics",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -22009,8 +28483,32 @@
   },
   {
     "code": "MATH171",
+    "title": "Abstract Algebra",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH171",
     "title": "Abstract Algebra I",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH171",
+    "title": "Abstract Algebra I:Groups&Rings",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH172",
+    "title": "Abstract Algebra 2: Galois Thry",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH172",
+    "title": "Abstract Algebra II: Galois Thry",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -22020,9 +28518,21 @@
     "credits": 3.0
   },
   {
+    "code": "MATH172",
+    "title": "Abstrct Algebra II:Galois Theory",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "MATH173",
     "title": "Advanced Linear Algebra",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH174",
+    "title": "Abstract Alg II: Represent Thry",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -22038,15 +28548,33 @@
     "credits": 3.0
   },
   {
+    "code": "MATH175",
+    "title": "Number Theory and Cryptography",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "MATH176",
     "title": "Algebraic Geometry",
     "campus": "hmc",
     "credits": 3.0
   },
   {
+    "code": "MATH176",
+    "title": "Analytic Number Theory",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "MATH177",
     "title": "Advanced Topics in Algebra",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH177",
+    "title": "Combinatorial Group Theory",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -22057,8 +28585,20 @@
   },
   {
     "code": "MATH180",
+    "title": "Intro to PDEs",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH180",
     "title": "Intro to Partial Differential Eq",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH180",
+    "title": "Partial Differential Equations",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -22080,6 +28620,12 @@
     "credits": 3.0
   },
   {
+    "code": "MATH183",
+    "title": "Modeling and Simulation",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "MATH184",
     "title": "Graduate Partial Diff Equations",
     "campus": "hmc",
@@ -22098,9 +28644,39 @@
     "credits": 3.0
   },
   {
+    "code": "MATH186",
+    "title": "Stochastic Operations Research",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH187",
+    "title": "Determin Meth Operation Research",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH187",
+    "title": "Deterministic Operations Resrch",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "MATH187",
     "title": "Operations Research",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH188",
+    "title": "Calculus of Variations",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH188",
+    "title": "Game Theory",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -22110,15 +28686,21 @@
     "credits": 3.0
   },
   {
-    "code": "MATH189",
-    "title": "Special Topics in Mathematics",
-    "campus": "hmc",
+    "code": "MATH188",
+    "title": "Topics in Applied Mathematics",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "MATH189A",
     "title": "Algebraic Geometry",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH189A",
+    "title": "Geometric Group Theory",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -22142,6 +28724,12 @@
   {
     "code": "MATH189E",
     "title": "Topics in Partial Diff Equations",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH189E",
+    "title": "Topics in Partial Diff. Equatns.",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -22207,6 +28795,12 @@
   },
   {
     "code": "MATH189R",
+    "title": "Big Data Analytics",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH189R",
     "title": "Mathematics of Big Data I",
     "campus": "hmc",
     "credits": 3.0
@@ -22218,9 +28812,21 @@
     "credits": 3.0
   },
   {
+    "code": "MATH189",
+    "title": "Special Topics in Mathematics",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "MATH189T",
     "title": "Special Topics in Combinatorics",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH189",
+    "title": "Topics in Applied Mathematics",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -22266,6 +28872,12 @@
     "credits": 3.0
   },
   {
+    "code": "MATH190",
+    "title": "Senior Seminar in Mathematics",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "MATH191",
     "title": "Senior Thesis in Mathematics",
     "campus": "po",
@@ -22296,12 +28908,6 @@
     "credits": 3.0
   },
   {
-    "code": "MATH197",
-    "title": "Senior Thesis in Mathematics",
-    "campus": "hmc",
-    "credits": 3.0
-  },
-  {
     "code": "MATH197A",
     "title": "Directed Research in Math",
     "campus": "cmc",
@@ -22314,14 +28920,38 @@
     "credits": 3.0
   },
   {
-    "code": "MATH198",
-    "title": "Undergraduate Mathematics Forum",
+    "code": "MATH197",
+    "title": "Selected Topics in Mathematics",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH197",
+    "title": "Senior Thesis in Mathematics",
     "campus": "hmc",
     "credits": 3.0
   },
   {
-    "code": "MATH199",
-    "title": "Mathematics Colloquium",
+    "code": "MATH198",
+    "title": "Independent Internship: Math",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH198",
+    "title": "Math Forum",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH198",
+    "title": "Summer Reading & Research",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH198",
+    "title": "Undergraduate Mathematics Forum",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -22338,9 +28968,33 @@
     "credits": 3.0
   },
   {
+    "code": "MATH199",
+    "title": "Independent Study in Math",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH199",
+    "title": "Independent Study in Mathematics",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH199",
+    "title": "Mathematics Colloquium",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "MATH199RAPO",
     "title": "Mathematics:Research Asst.",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH199",
+    "title": "Senior Thesis",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -22434,13 +29088,13 @@
     "credits": 3.0
   },
   {
-    "code": "MATH361",
+    "code": "MATH361A",
     "title": "Numerical Methods for Finance",
     "campus": "cgu",
     "credits": 3.0
   },
   {
-    "code": "MATH361A",
+    "code": "MATH361",
     "title": "Numerical Methods for Finance",
     "campus": "cgu",
     "credits": 3.0
@@ -22454,6 +29108,12 @@
   {
     "code": "MATH368",
     "title": "Advanced Numerical Analysis",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH368",
+    "title": "Numerical Methods Matrix Comp",
     "campus": "cgu",
     "credits": 3.0
   },
@@ -22472,6 +29132,12 @@
   {
     "code": "MATH386",
     "title": "Graph Theory",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH386",
+    "title": "Image Processing",
     "campus": "cgu",
     "credits": 3.0
   },
@@ -22550,6 +29216,12 @@
   {
     "code": "MATH462",
     "title": "Bayesian Meth & Machine Learning",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "MATH462",
+    "title": "Mathematics of Machine Learning",
     "campus": "cgu",
     "credits": 3.0
   },
@@ -22651,7 +29323,25 @@
   },
   {
     "code": "MCSI195",
+    "title": "Conspiracy Theory & Fact",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "MCSI195",
+    "title": "Divine Hiddeness",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "MCSI195",
     "title": "Islam Beyond Ideolgical ...",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "MCSI195",
+    "title": "Perception in Social World",
     "campus": "pz",
     "credits": 3.0
   },
@@ -22710,20 +29400,26 @@
     "credits": 3.0
   },
   {
-    "code": "MGT302",
-    "title": "Curr Marketing Issues",
-    "campus": "cgu",
-    "credits": 3.0
-  },
-  {
     "code": "MGT302A",
     "title": "Curr Marketing Tpcs: Retailing",
     "campus": "cgu",
     "credits": 3.0
   },
   {
+    "code": "MGT302",
+    "title": "Curr Marketing Issues",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
     "code": "MGT305",
     "title": "Strategy & Business Planning",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "MGT306",
+    "title": "Business Analytics",
     "campus": "cgu",
     "credits": 3.0
   },
@@ -22980,12 +29676,6 @@
     "credits": 3.0
   },
   {
-    "code": "MGT380",
-    "title": "Drucker Philosophy",
-    "campus": "cgu",
-    "credits": 3.0
-  },
-  {
     "code": "MGT380A",
     "title": "Drucker Practice of Management",
     "campus": "cgu",
@@ -23000,6 +29690,12 @@
   {
     "code": "MGT380C",
     "title": "Practice of MGT: Prof Project",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "MGT380",
+    "title": "Drucker Philosophy",
     "campus": "cgu",
     "credits": 3.0
   },
@@ -23023,6 +29719,12 @@
   },
   {
     "code": "MGT402",
+    "title": "Asset Management Practicum",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "MGT402",
     "title": "Assets Management Practicum",
     "campus": "cgu",
     "credits": 3.0
@@ -23030,6 +29732,12 @@
   {
     "code": "MGT404",
     "title": "Business to Business Marketing",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "MGT405",
+    "title": "Entrepreneurship and Innovation",
     "campus": "cgu",
     "credits": 3.0
   },
@@ -23058,6 +29766,12 @@
     "credits": 3.0
   },
   {
+    "code": "MGT409",
+    "title": "Systems Thinking",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
     "code": "MGT410",
     "title": "Strategic Risk Management",
     "campus": "cgu",
@@ -23082,14 +29796,14 @@
     "credits": 3.0
   },
   {
-    "code": "MGT475",
-    "title": "Fixed Income & Other Investments",
+    "code": "MGT475A",
+    "title": "Income/Investment/Management",
     "campus": "cgu",
     "credits": 3.0
   },
   {
-    "code": "MGT475A",
-    "title": "Income/Investment/Management",
+    "code": "MGT475",
+    "title": "Fixed Income & Other Investments",
     "campus": "cgu",
     "credits": 3.0
   },
@@ -23136,13 +29850,13 @@
     "credits": 3.0
   },
   {
-    "code": "MINORREQ1",
+    "code": "MINORREQ10HM",
     "title": "Minor Requirement",
     "campus": "hmc",
     "credits": 3.0
   },
   {
-    "code": "MINORREQ10HM",
+    "code": "MINORREQ1",
     "title": "Minor Requirement",
     "campus": "hmc",
     "credits": 3.0
@@ -23193,6 +29907,12 @@
     "code": "MINORREQ9",
     "title": "Minor Requirement",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "MLLC001",
+    "title": "American Sign Language",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -23298,12 +30018,6 @@
     "credits": 3.0
   },
   {
-    "code": "MLLC133",
-    "title": "Written Analysis",
-    "campus": "pz",
-    "credits": 3.0
-  },
-  {
     "code": "MLLC133A",
     "title": "Personal Power & Public Responsi",
     "campus": "pz",
@@ -23312,6 +30026,12 @@
   {
     "code": "MLLC133B",
     "title": "It's a Mystery",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "MLLC133",
+    "title": "Written Analysis",
     "campus": "pz",
     "credits": 3.0
   },
@@ -23436,12 +30156,6 @@
     "credits": 3.0
   },
   {
-    "code": "MS",
-    "title": "Media Studies: Directed Readings",
-    "campus": "po",
-    "credits": 3.0
-  },
-  {
     "code": "MS003",
     "title": "Transatlantic Blk/Asian Film/Lit",
     "campus": "pz",
@@ -23496,6 +30210,12 @@
     "credits": 3.0
   },
   {
+    "code": "MS046",
+    "title": "Recent Issues in MS & New Media",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "MS047",
     "title": "Independent Film Cultures",
     "campus": "pz",
@@ -23511,6 +30231,18 @@
     "code": "MS049",
     "title": "Intro to Media Studies",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MS049",
+    "title": "Introduction to Media Studies",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "MS050",
+    "title": "Intro to Film",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -23557,6 +30289,12 @@
   },
   {
     "code": "MS057",
+    "title": "Intro to Game Design",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "MS057",
     "title": "Screenwriting",
     "campus": "pz",
     "credits": 3.0
@@ -23577,6 +30315,12 @@
     "code": "MS060",
     "title": "Documentary: Fact and Fiction",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "MS060",
+    "title": "Media and Migration",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -23618,6 +30362,12 @@
   {
     "code": "MS073",
     "title": "Race, Theory and Media",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "MS073",
+    "title": "Technology, Capitalism & Race",
     "campus": "pz",
     "credits": 3.0
   },
@@ -23694,6 +30444,12 @@
     "credits": 3.0
   },
   {
+    "code": "MS085",
+    "title": "Intro to Film in the Digital Age",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "MS086",
     "title": "History of Ethnographic Film",
     "campus": "pz",
@@ -23708,12 +30464,6 @@
   {
     "code": "MS088",
     "title": "Mexican Visual Cultures",
-    "campus": "pz",
-    "credits": 3.0
-  },
-  {
-    "code": "MS089",
-    "title": "Mexican Film History",
     "campus": "pz",
     "credits": 3.0
   },
@@ -23736,8 +30486,20 @@
     "credits": 3.0
   },
   {
+    "code": "MS089",
+    "title": "Mexican Film History",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "MS091",
     "title": "History of American Broadcasting",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MS092",
+    "title": "Principles of Television Study",
     "campus": "po",
     "credits": 3.0
   },
@@ -23750,6 +30512,12 @@
   {
     "code": "MS093",
     "title": "Experimental Media Studio",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "MS094",
+    "title": "Collaborative Art of Filmmaking",
     "campus": "pz",
     "credits": 3.0
   },
@@ -23784,6 +30552,12 @@
     "credits": 3.0
   },
   {
+    "code": "MS098",
+    "title": "Media of Middle East",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "MS099",
     "title": "Advanced Editing",
     "campus": "pz",
@@ -23792,6 +30566,12 @@
   {
     "code": "MS100",
     "title": "Asian Americans in Media",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "MS101",
+    "title": "Asian Amer Media in Communities",
     "campus": "pz",
     "credits": 3.0
   },
@@ -23816,6 +30596,12 @@
   {
     "code": "MS104",
     "title": "Modern So African Lit and Film",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "MS105",
+    "title": "Game Sound",
     "campus": "pz",
     "credits": 3.0
   },
@@ -23874,6 +30660,12 @@
     "credits": 3.0
   },
   {
+    "code": "MS113",
+    "title": "The Art of Gesture and Talk",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "MS114",
     "title": "Film Sound",
     "campus": "pz",
@@ -23916,8 +30708,32 @@
     "credits": 3.0
   },
   {
+    "code": "MS120",
+    "title": "Social/Media",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "MS120",
+    "title": "Video Games & Media Discourse",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "MS121",
+    "title": "Cultural Politics of Self Care",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "MS121",
     "title": "Mixed Reality",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "MS123",
+    "title": "Embodying Identity in Practice",
     "campus": "pz",
     "credits": 3.0
   },
@@ -23953,6 +30769,12 @@
   },
   {
     "code": "MS131",
+    "title": "Interactive Narrative Design",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "MS131",
     "title": "The Two\" and Media\"",
     "campus": "po",
     "credits": 3.0
@@ -23976,14 +30798,14 @@
     "credits": 3.0
   },
   {
-    "code": "MS135",
-    "title": "Learning From YouTube",
+    "code": "MS135A",
+    "title": "Learning From YouTube-Practicum",
     "campus": "pz",
     "credits": 3.0
   },
   {
-    "code": "MS135A",
-    "title": "Learning From YouTube-Practicum",
+    "code": "MS135",
+    "title": "Learning From YouTube",
     "campus": "pz",
     "credits": 3.0
   },
@@ -24090,12 +30912,6 @@
     "credits": 3.0
   },
   {
-    "code": "MS149",
-    "title": "Theory & Aesthetics of Televisn",
-    "campus": "pz",
-    "credits": 3.0
-  },
-  {
     "code": "MS149E",
     "title": "The Brief History of Film Theory",
     "campus": "po",
@@ -24144,6 +30960,30 @@
     "credits": 3.0
   },
   {
+    "code": "MS149T",
+    "title": "Seminar: Critical Studies",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MS149",
+    "title": "Theory & Aesthetcs of Television",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "MS149",
+    "title": "Theory & Aesthetics of Televisn",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "MS149",
+    "title": "Theory& Aesthetics of Television",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "MS151",
     "title": "Television Genres",
     "campus": "pz",
@@ -24169,6 +31009,12 @@
   },
   {
     "code": "MS160",
+    "title": "Computational Photography II",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "MS160",
     "title": "Japanese Film: Canon to Fringe",
     "campus": "po",
     "credits": 3.0
@@ -24183,6 +31029,12 @@
     "code": "MS162",
     "title": "Asia's Media Ecologies",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MS170",
+    "title": "Digital Cinema: Expr. Animation",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -24210,15 +31062,15 @@
     "credits": 3.0
   },
   {
-    "code": "MS176",
-    "title": "Portraits of the Artists",
-    "campus": "pz",
+    "code": "MS175",
+    "title": "Horror\" and The American Horror\"",
+    "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "MS179",
-    "title": "Special Topics in Media Studies",
-    "campus": "hmc",
+    "code": "MS176",
+    "title": "Portraits of the Artists",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -24252,9 +31104,21 @@
     "credits": 3.0
   },
   {
+    "code": "MS179",
+    "title": "Special Topics in Media Studies",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "MS180",
     "title": "Jr Sem in Media Studies Prod",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "MS180",
+    "title": "The War Film",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -24276,12 +31140,6 @@
     "credits": 3.0
   },
   {
-    "code": "MS190",
-    "title": "Senior Seminar",
-    "campus": "po",
-    "credits": 3.0
-  },
-  {
     "code": "MS190A",
     "title": "Senior Seminar in Media Studies",
     "campus": "pz",
@@ -24294,6 +31152,24 @@
     "credits": 3.0
   },
   {
+    "code": "MS190",
+    "title": "Senior Seminar",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MS191",
+    "title": "Media Internship",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "MS191",
+    "title": "Senior Thesis",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "MS191",
     "title": "Senior Thesis in Media Studies",
     "campus": "pz",
@@ -24301,8 +31177,32 @@
   },
   {
     "code": "MS192",
+    "title": "Advanced Media Project",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "MS192",
+    "title": "Senior Project",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MS192",
     "title": "Senior Project in Media Studies",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "MS192",
+    "title": "Snr Prjt & Ppr  in Media Studies",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "MS192",
+    "title": "Sr Project in Media Studies",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -24330,6 +31230,24 @@
     "credits": 3.0
   },
   {
+    "code": "MS197",
+    "title": "Media Praxis",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "MS198",
+    "title": "Advanced Media Project",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "MS198",
+    "title": "Independent Internship",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "MS198",
     "title": "Summer Reading & Research",
     "campus": "po",
@@ -24345,6 +31263,12 @@
     "code": "MS999",
     "title": "Independent Study",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "MSL001A",
+    "title": "Amer Mil Hist; Civil War-Present",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -24420,8 +31344,14 @@
     "credits": 3.0
   },
   {
-    "code": "MUS",
-    "title": "Bass Level I (Indiv Instruc)",
+    "code": "MS",
+    "title": "Media St:Independent Research",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MS",
+    "title": "Media Studies: Directed Readings",
     "campus": "po",
     "credits": 3.0
   },
@@ -24468,14 +31398,14 @@
     "credits": 3.0
   },
   {
-    "code": "MUS031",
-    "title": "Pomona College Choir",
+    "code": "MUS031-042PO",
+    "title": "Pomona College Music Ensembles",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "MUS031-042PO",
-    "title": "Pomona College Music Ensembles",
+    "code": "MUS031",
+    "title": "Pomona College Choir",
     "campus": "po",
     "credits": 3.0
   },
@@ -24486,13 +31416,13 @@
     "credits": 3.0
   },
   {
-    "code": "MUS033",
+    "code": "MUS033B",
     "title": "Pomona College Orchestra",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "MUS033B",
+    "code": "MUS033",
     "title": "Pomona College Orchestra",
     "campus": "po",
     "credits": 3.0
@@ -24660,6 +31590,12 @@
     "credits": 3.0
   },
   {
+    "code": "MUS066",
+    "title": "Poet Sings: Verlaine",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "MUS067",
     "title": "Film Music",
     "campus": "hmc",
@@ -24680,6 +31616,12 @@
   {
     "code": "MUS071",
     "title": "Music in Africa",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS071",
+    "title": "Music in Punjabi Culture",
     "campus": "po",
     "credits": 3.0
   },
@@ -24709,6 +31651,12 @@
   },
   {
     "code": "MUS077",
+    "title": "Jamaican Musical Aesthetics",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS077",
     "title": "Music & Performance of Africa",
     "campus": "po",
     "credits": 3.0
@@ -24721,14 +31669,44 @@
   },
   {
     "code": "MUS080",
+    "title": "Lab, Theory I",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS080",
     "title": "Music Theory I",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "MUS081",
+    "title": "Intro to Music: Sound & Meaning",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS081",
     "title": "Introduction to Music",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS081",
+    "title": "Lab, Theory II",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS081",
+    "title": "Music Theory II",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS082",
+    "title": "Lab, Theory III",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -24741,12 +31719,6 @@
     "code": "MUS084",
     "title": "Jazz Improvisation",
     "campus": "hmc",
-    "credits": 3.0
-  },
-  {
-    "code": "MUS085",
-    "title": "Group Piano",
-    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -24774,6 +31746,12 @@
     "credits": 3.0
   },
   {
+    "code": "MUS085",
+    "title": "Group Piano",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "MUS086",
     "title": "Music in Theory and Practice",
     "campus": "po",
@@ -24787,14 +31765,14 @@
   },
   {
     "code": "MUS088",
-    "title": "Introduction to Computer Music",
-    "campus": "hmc",
+    "title": "Global Musical Instruments",
+    "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "MUS089",
-    "title": "Group Voice",
-    "campus": "sc",
+    "code": "MUS088",
+    "title": "Introduction to Computer Music",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -24804,9 +31782,27 @@
     "credits": 3.0
   },
   {
+    "code": "MUS089A",
+    "title": "Pop Music in East Asia",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS089B",
+    "title": "Group Voice: 1st & 2nd Year",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "MUS089B",
     "title": "Music of the Pacific Rim",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS089C",
+    "title": "Group Voice: 3rd & 4th Year",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -24822,14 +31818,32 @@
     "credits": 3.0
   },
   {
+    "code": "MUS089D",
+    "title": "Group Voice: 3rd & 4th Year",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "MUS089E",
     "title": "Music of China",
     "campus": "po",
     "credits": 3.0
   },
   {
+    "code": "MUS089",
+    "title": "Group Voice",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "MUS091",
     "title": "Perception, Mind & Modern Sound",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS091",
+    "title": "Sound, Cognition, and History",
     "campus": "po",
     "credits": 3.0
   },
@@ -24919,6 +31933,12 @@
   },
   {
     "code": "MUS104",
+    "title": "Music Lit & Analysis Since 1900",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS104",
     "title": "Music Since 1900",
     "campus": "hmc",
     "credits": 3.0
@@ -24960,6 +31980,18 @@
     "credits": 3.0
   },
   {
+    "code": "MUS117",
+    "title": "Twentieth-Century Music",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS118",
+    "title": "Composition",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "MUS118",
     "title": "Music in the United States",
     "campus": "hmc",
@@ -24968,12 +32000,6 @@
   {
     "code": "MUS119",
     "title": "Women and Gender in Music",
-    "campus": "sc",
-    "credits": 3.0
-  },
-  {
-    "code": "MUS120",
-    "title": "Music in Christian Practice",
     "campus": "sc",
     "credits": 3.0
   },
@@ -24990,9 +32016,27 @@
     "credits": 3.0
   },
   {
+    "code": "MUS120",
+    "title": "Music in Christian Practice",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS121",
+    "title": "Music of the Spirits",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "MUS121",
     "title": "Sem in Music Hist(Before 1750)",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS122",
+    "title": "Color of Mus:Race in Blues/Jazz",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -25022,6 +32066,12 @@
   {
     "code": "MUS126",
     "title": "Music in East Asia and Diaspora",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS127",
+    "title": "Cultural History of Rap",
     "campus": "sc",
     "credits": 3.0
   },
@@ -25200,12 +32250,6 @@
     "credits": 3.0
   },
   {
-    "code": "MUS172",
-    "title": "Chamber Music",
-    "campus": "sc",
-    "credits": 3.0
-  },
-  {
     "code": "MUS172A",
     "title": "Chamber Music: 1st & 2nd Year",
     "campus": "sc",
@@ -25224,14 +32268,14 @@
     "credits": 3.0
   },
   {
-    "code": "MUS172D",
-    "title": "Chamber Music: 3rd & 4th Year",
+    "code": "MUS172",
+    "title": "Chamber Music",
     "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "MUS173",
-    "title": "Claremont Concert Choir",
+    "code": "MUS172D",
+    "title": "Chamber Music: 3rd & 4th Year",
     "campus": "sc",
     "credits": 3.0
   },
@@ -25254,14 +32298,14 @@
     "credits": 3.0
   },
   {
-    "code": "MUS173D",
-    "title": "Clmnt Concert Choir:3rd/4th Year",
+    "code": "MUS173",
+    "title": "Claremont Concert Choir",
     "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "MUS174",
-    "title": "Claremont Chamber Choir",
+    "code": "MUS173D",
+    "title": "Clmnt Concert Choir:3rd/4th Year",
     "campus": "sc",
     "credits": 3.0
   },
@@ -25284,14 +32328,14 @@
     "credits": 3.0
   },
   {
-    "code": "MUS174D",
-    "title": "Clmnt Chamber Choir: 3rd/4th Yr",
+    "code": "MUS174",
+    "title": "Claremont Chamber Choir",
     "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "MUS175",
-    "title": "Claremont Concert Orchestra",
+    "code": "MUS174D",
+    "title": "Clmnt Chamber Choir: 3rd/4th Yr",
     "campus": "sc",
     "credits": 3.0
   },
@@ -25314,6 +32358,12 @@
     "credits": 3.0
   },
   {
+    "code": "MUS175",
+    "title": "Claremont Concert Orchestra",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "MUS175D",
     "title": "Concert Orchestra: 3rd & 4th Yr",
     "campus": "sc",
@@ -25323,12 +32373,6 @@
     "code": "MUS176",
     "title": "Claremont Treble Singers",
     "campus": "sc",
-    "credits": 3.0
-  },
-  {
-    "code": "MUS177",
-    "title": "Music for Composers & Performers",
-    "campus": "po",
     "credits": 3.0
   },
   {
@@ -25368,9 +32412,9 @@
     "credits": 3.0
   },
   {
-    "code": "MUS178",
-    "title": "Diction for Advanced Vocalists",
-    "campus": "sc",
+    "code": "MUS177",
+    "title": "Music for Composers & Performers",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -25386,9 +32430,9 @@
     "credits": 3.0
   },
   {
-    "code": "MUS179",
-    "title": "Special Topics in Music",
-    "campus": "hmc",
+    "code": "MUS178",
+    "title": "Diction for Advanced Vocalists",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -25410,9 +32454,27 @@
     "credits": 3.0
   },
   {
+    "code": "MUS179",
+    "title": "Keyboard Instruments for Pianist",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS179",
+    "title": "Special Topics in Music",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "MUS180",
     "title": "Adv Topics in Music History",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS180",
+    "title": "Fortepiano",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -25436,6 +32498,12 @@
   {
     "code": "MUS184",
     "title": "20th C Music History & Theory",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS184",
+    "title": "Lab, 20th C Music Hist & Theory",
     "campus": "po",
     "credits": 3.0
   },
@@ -25464,14 +32532,26 @@
     "credits": 3.0
   },
   {
+    "code": "MUS190",
+    "title": "Senior Music Colloquium",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS191H",
+    "title": "Honors Senior Thesis",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "MUS191",
     "title": "Senior Thesis",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "MUS191H",
-    "title": "Honors Senior Thesis",
+    "code": "MUS191",
+    "title": "Senior Thesis in Music",
     "campus": "sc",
     "credits": 3.0
   },
@@ -25491,6 +32571,12 @@
     "code": "MUS197",
     "title": "Independent Study in Music",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS198",
+    "title": "Independent Internship",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -25518,9 +32604,411 @@
     "credits": 3.0
   },
   {
+    "code": "MUS",
+    "title": "Bass Level I",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Bass Level I (Indiv Instruc)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Bass Level II (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Bassoon Level I (Indiv Instruc)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Bassoon Level II (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Clarinet Level I",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Clarinet Level I (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Clarinet Level II (Indiv Inst)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Clarinet Level II (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Conducting",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Conducting: 1st & 2nd Year",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Conducting: 3rd & 4th Year",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Euphonium Level I (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Euphonium Level II (Indiv Inst)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Flute Level I",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Flute Level I (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Flute Level II (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "French Horn Level I (Indiv Inst)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "French Horn Level II (Indiv Ins)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Guitar Level I",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Guitar Level I (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Guitar Level II (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Harp Level I (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Harp Level II (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Harpsichord Level I (Indiv Inst)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Harpsichord Level II (Indiv In)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Harpsichord Level II (Indiv Ins)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "MUSIC",
     "title": "Lessons/Ensembles for PAC 6",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Music: Directed Readings",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Music: Independent Research",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Music: Research Assistantship",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Oboe Level I (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Oboe Level II (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Organ Level I (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Organ Level II (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Percussion Level I",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Percussion Level I (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Percussion Level II (Indiv Ins)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Piano Level I (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Piano Level II (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Piano: 1st & 2nd Year",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Piano: 3rd & 4th Year",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Saxophone Level I (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Saxophone Level II (Indiv Inst)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Saxophone Level II (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Trombone Level I (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Trombone Level II (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Trumpet Level I",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Trumpet Level I (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Trumpet Level II (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Tuba Level I (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Tuba Level II (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Viola Level I (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Viola Level II (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Violin Level I (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Violin Level II (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Violin: 1st & 2nd Year",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Violin: 3rd & 4th Year",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Violincello Lev I (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Violincello Lev II (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Violincello Level I(Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Violoncello Lev I (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Violoncello Lev II (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Voice Level I",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Voice Level I (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Voice Level II (Indiv Instr)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Voice: 1st & 2nd Year",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "MUS",
+    "title": "Voice: 3rd & 4th Year",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -25554,6 +33042,18 @@
     "credits": 3.0
   },
   {
+    "code": "NEUR101",
+    "title": "Lab, Intro to Neuroscience",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "NEUR102",
+    "title": "Lab, Neuroethology",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "NEUR102",
     "title": "Neuroethology: Mech Behav w/Lab",
     "campus": "po",
@@ -25578,6 +33078,12 @@
     "credits": 3.0
   },
   {
+    "code": "NEUR110",
+    "title": "Lab, Developmental Neurobiology",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "NEUR123",
     "title": "Cognitive Neuroscience",
     "campus": "sc",
@@ -25590,6 +33096,18 @@
     "credits": 3.0
   },
   {
+    "code": "NEUR123",
+    "title": "The Stressed Brain",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "NEUR130",
+    "title": "Lab, Vertebrate Sensory Systems",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "NEUR130",
     "title": "Vertebrate Sensory Systems w/Lab",
     "campus": "po",
@@ -25598,6 +33116,12 @@
   {
     "code": "NEUR143",
     "title": "Human Brain: Neurons-Behav w/Lab",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "NEUR143",
+    "title": "Lab, Human Brain",
     "campus": "po",
     "credits": 3.0
   },
@@ -25621,7 +33145,19 @@
   },
   {
     "code": "NEUR168",
+    "title": "Genes and Behavior Lab",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "NEUR168",
     "title": "Genes and Behavior w/ Lab",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "NEUR178",
+    "title": "Neurobiology Lab",
     "campus": "po",
     "credits": 3.0
   },
@@ -25629,6 +33165,12 @@
     "code": "NEUR178",
     "title": "Neurobiology with Lab",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "NEUR182",
+    "title": "Machine Learning w Neural Signal",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -25686,20 +33228,14 @@
     "credits": 3.0
   },
   {
-    "code": "NEUR189T",
-    "title": "Neuroendocrinology",
-    "campus": "po",
-    "credits": 3.0
-  },
-  {
     "code": "NEUR189TLPO",
     "title": "Lab, Neuroendocrinology",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "NEUR190",
-    "title": "Senior Seminar: Advanced Topics",
+    "code": "NEUR189T",
+    "title": "Neuroendocrinology",
     "campus": "po",
     "credits": 3.0
   },
@@ -25710,9 +33246,21 @@
     "credits": 3.0
   },
   {
+    "code": "NEUR190",
+    "title": "Senior Seminar: Advanced Topics",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "NEUR191",
     "title": "One-Sem Thesis in Neuroscience",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "NEUR191",
+    "title": "Senior Library Thesis",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -25735,14 +33283,14 @@
   },
   {
     "code": "NEUR198",
-    "title": "Summer Reading & Research",
-    "campus": "po",
+    "title": "Independent Internship",
+    "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "NEUR199",
-    "title": "Independent Study:  Neuroscience",
-    "campus": "sc",
+    "code": "NEUR198",
+    "title": "Summer Reading & Research",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -25755,6 +33303,12 @@
     "code": "NEUR199IRPO",
     "title": "Neuroscience: Indep Research",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "NEUR199",
+    "title": "Independent Study:  Neuroscience",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -25830,12 +33384,6 @@
     "credits": 3.0
   },
   {
-    "code": "ONT104",
-    "title": "Social Change Practicum",
-    "campus": "pz",
-    "credits": 3.0
-  },
-  {
     "code": "ONT104A",
     "title": "Social Change Practicum",
     "campus": "pz",
@@ -25843,6 +33391,12 @@
   },
   {
     "code": "ONT104B",
+    "title": "Social Change Practicum",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ONT104",
     "title": "Social Change Practicum",
     "campus": "pz",
     "credits": 3.0
@@ -25874,6 +33428,12 @@
   {
     "code": "ONT170",
     "title": "Advanced Research Practicum",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ONT170",
+    "title": "Radical Resrch & Social Prtnshps",
     "campus": "pz",
     "credits": 3.0
   },
@@ -26070,6 +33630,12 @@
     "credits": 3.0
   },
   {
+    "code": "ORST161",
+    "title": "College Inside-Out",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "ORST163",
     "title": "Organizational Aspects of Ed",
     "campus": "pz",
@@ -26106,14 +33672,14 @@
     "credits": 3.0
   },
   {
-    "code": "ORST177",
-    "title": "Seminar in Organizational Comm",
+    "code": "ORST177C",
+    "title": "Seminar in Organizational Comm.",
     "campus": "pz",
     "credits": 3.0
   },
   {
-    "code": "ORST177C",
-    "title": "Seminar in Organizational Comm.",
+    "code": "ORST177",
+    "title": "Seminar in Organizational Comm",
     "campus": "pz",
     "credits": 3.0
   },
@@ -26130,12 +33696,6 @@
     "credits": 3.0
   },
   {
-    "code": "ORST198",
-    "title": "Topics in Orgs: Dynamics & Chang",
-    "campus": "pz",
-    "credits": 3.0
-  },
-  {
     "code": "ORST198B",
     "title": "Authoritarian Institutions",
     "campus": "pz",
@@ -26148,8 +33708,20 @@
     "credits": 3.0
   },
   {
+    "code": "ORST198",
+    "title": "Independent Internship",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "ORST198J",
     "title": "Sustainable Labor:Future of Work",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ORST198",
+    "title": "Topics in Orgs: Dynamics & Chang",
     "campus": "pz",
     "credits": 3.0
   },
@@ -26202,14 +33774,14 @@
     "credits": 3.0
   },
   {
-    "code": "PAC1",
-    "title": "PAC1 FULFILLMENT",
+    "code": "PAC10",
+    "title": "PAC10 FULFILLMENT",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "PAC10",
-    "title": "PAC10 FULFILLMENT",
+    "code": "PAC1",
+    "title": "PAC1 FULFILLMENT",
     "campus": "po",
     "credits": 3.0
   },
@@ -26262,19 +33834,13 @@
     "credits": 3.0
   },
   {
-    "code": "PE",
-    "title": "Physical Ed: Directed Readings",
+    "code": "PE001A",
+    "title": "Aerobics",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "PE001",
-    "title": "Physical Education Activity",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
-    "code": "PE001A",
     "title": "Aerobics",
     "campus": "po",
     "credits": 3.0
@@ -26286,8 +33852,8 @@
     "credits": 3.0
   },
   {
-    "code": "PE002",
-    "title": "Phys. Ed. Teams & Club Sports",
+    "code": "PE001",
+    "title": "Physical Education Activity",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -26298,14 +33864,32 @@
     "credits": 3.0
   },
   {
-    "code": "PE003",
-    "title": "Physical Fitness for Life",
+    "code": "PE002",
+    "title": "Phys. Ed. Teams & Club Sports",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "PE004",
-    "title": "Breakdancing/Hip Hop",
+    "code": "PE002",
+    "title": "Pilates Method",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE003",
+    "title": "Introduction to Fitness",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE003",
+    "title": "Personalized Fitness Training",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE003",
+    "title": "Physical Fitness for Life",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -26316,8 +33900,38 @@
     "credits": 3.0
   },
   {
+    "code": "PE004A",
+    "title": "Breakdancing/Hip Hop-Beg/Int",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE004",
+    "title": "Breakdancing/Hip Hop",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE004",
+    "title": "Tough Mudder Training",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "PE005",
     "title": "3X3FIT",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE006B",
+    "title": "TRX-Total Body Resistance",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE006",
+    "title": "Core Training",
     "campus": "po",
     "credits": 3.0
   },
@@ -26328,20 +33942,14 @@
     "credits": 3.0
   },
   {
-    "code": "PE006B",
-    "title": "TRX-Total Body Resistance",
-    "campus": "po",
+    "code": "PE007A",
+    "title": "CATZ-Beginning",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PE007",
     "title": "Aerobics",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
-    "code": "PE007A",
-    "title": "CATZ-Beginning",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -26352,9 +33960,9 @@
     "credits": 3.0
   },
   {
-    "code": "PE008",
-    "title": "Fitness Class",
-    "campus": "cmc",
+    "code": "PE007",
+    "title": "Triathlon Training",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -26376,20 +33984,38 @@
     "credits": 3.0
   },
   {
+    "code": "PE008",
+    "title": "Conditioning - Advanced",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE008",
+    "title": "Fitness Class",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "PE009",
     "title": "Half Marathon Training",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "PE010",
-    "title": "Jogging",
-    "campus": "cmc",
+    "code": "PE009",
+    "title": "Jogging/Running",
+    "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "PE011",
-    "title": "Running",
+    "code": "PE010",
+    "title": "Hiking/Geocaching",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE010",
+    "title": "Jogging",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -26400,14 +34026,32 @@
     "credits": 3.0
   },
   {
-    "code": "PE012",
-    "title": "Run with the Dean",
+    "code": "PE011A",
+    "title": "Ropes Course and Leadership Trng",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE011",
+    "title": "Outdoor Leadership",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE011",
+    "title": "Running",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "PE013",
-    "title": "Pilates-Reformer Based",
+    "code": "PE012",
+    "title": "Beginning Backpacking",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE012",
+    "title": "Run with the Dean",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -26415,6 +34059,12 @@
     "code": "PE013A",
     "title": "Pilates-Group Fitness Reformer",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE013",
+    "title": "Aqua Fit",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -26430,8 +34080,8 @@
     "credits": 3.0
   },
   {
-    "code": "PE014",
-    "title": "Spinning-Stationary Bike",
+    "code": "PE013",
+    "title": "Pilates-Reformer Based",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -26442,9 +34092,27 @@
     "credits": 3.0
   },
   {
+    "code": "PE014",
+    "title": "Beginning Rock Climbing",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE014",
+    "title": "Spinning-Stationary Bike",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "PE015",
     "title": "Swim Conditioning",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE015",
+    "title": "Swim Fitness",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -26460,15 +34128,21 @@
     "credits": 3.0
   },
   {
+    "code": "PE016C",
+    "title": "Weight-Training- Advanced",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "PE016D",
     "title": "Free Weights",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "PE017",
-    "title": "Speed and Agility Class",
-    "campus": "cmc",
+    "code": "PE016",
+    "title": "Weight Training",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -26484,8 +34158,14 @@
     "credits": 3.0
   },
   {
-    "code": "PE018",
-    "title": "Self-Defense",
+    "code": "PE017",
+    "title": "Intro to Wilderness Survival",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE017",
+    "title": "Speed and Agility Class",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -26496,9 +34176,15 @@
     "credits": 3.0
   },
   {
-    "code": "PE019",
-    "title": "Fitness Bootcamp",
+    "code": "PE018",
+    "title": "Self-Defense",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE018",
+    "title": "Weight Training & Cardio",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -26514,14 +34200,38 @@
     "credits": 3.0
   },
   {
-    "code": "PE020",
-    "title": "Martial Arts-Intro",
+    "code": "PE019",
+    "title": "Circuit Strength Training",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE019",
+    "title": "Fitness Bootcamp",
     "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PE020A",
     "title": "Basic Yi Quan Standing Practice",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE020A",
+    "title": "Strength and Conditioning",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE020",
+    "title": "Cardio and Strength",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE020",
+    "title": "Martial Arts-Intro",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -26544,9 +34254,15 @@
     "credits": 3.0
   },
   {
-    "code": "PE022",
-    "title": "Bagua Chinese Martial Arts",
+    "code": "PE021",
+    "title": "Kokikai-ryu Aikido",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE021",
+    "title": "Yoga - Hatha Method I",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -26562,9 +34278,21 @@
     "credits": 3.0
   },
   {
+    "code": "PE022",
+    "title": "Bagua Chinese Martial Arts",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "PE023",
     "title": "Intro to Tae Kwon Do",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE023",
+    "title": "Yoga - Kundalini",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -26574,9 +34302,27 @@
     "credits": 3.0
   },
   {
+    "code": "PE024",
+    "title": "Running/Interval Training",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE025",
+    "title": "Introduction to the Weight Room",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "PE025",
     "title": "Karate-Shotokan",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE025",
+    "title": "Weight Training for Women",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -26586,9 +34332,9 @@
     "credits": 3.0
   },
   {
-    "code": "PE027",
-    "title": "Brazilian Jiu Jitsu",
-    "campus": "cmc",
+    "code": "PE026",
+    "title": "Shotokan Karate",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -26598,9 +34344,15 @@
     "credits": 3.0
   },
   {
-    "code": "PE028",
-    "title": "Wmn's Self-Defense Model Mugging",
+    "code": "PE027",
+    "title": "Brazilian Jiu Jitsu",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE027",
+    "title": "Martial Arts Tai Chi",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -26616,8 +34368,8 @@
     "credits": 3.0
   },
   {
-    "code": "PE029",
-    "title": "Tai Chi",
+    "code": "PE028",
+    "title": "Wmn's Self-Defense Model Mugging",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -26646,6 +34398,18 @@
     "credits": 3.0
   },
   {
+    "code": "PE029",
+    "title": "Tai Chi",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE030",
+    "title": "Contra Dance",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "PE030",
     "title": "Fly Fishing",
     "campus": "cmc",
@@ -26658,14 +34422,20 @@
     "credits": 3.0
   },
   {
+    "code": "PE032A",
+    "title": "Aerial Silks",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "PE032",
     "title": "Aerial Circus",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "PE032A",
-    "title": "Aerial Silks",
+    "code": "PE032B",
+    "title": "Aerial Circus Fitness Bootcamp",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -26688,6 +34458,12 @@
     "credits": 3.0
   },
   {
+    "code": "PE032",
+    "title": "Dance - Hip Hop",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "PE032E",
     "title": "Aerial Yoga & Conditioning",
     "campus": "cmc",
@@ -26700,14 +34476,26 @@
     "credits": 3.0
   },
   {
-    "code": "PE032G",
-    "title": "Aerial Silks/Trapeze/Hoops",
+    "code": "PE032F",
+    "title": "Aerial Circus Fitness Bootcamp",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "PE033",
-    "title": "Mountain Biking",
+    "code": "PE032F",
+    "title": "Aerial Silks Bootcamp",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE032G",
+    "title": "Aerial Silks/Trapeze/Hoop",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE032G",
+    "title": "Aerial Silks/Trapeze/Hoops",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -26730,8 +34518,14 @@
     "credits": 3.0
   },
   {
-    "code": "PE034",
-    "title": "Boxing",
+    "code": "PE033",
+    "title": "Mountain Biking",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE034A",
+    "title": "Boxing Fitness",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -26748,14 +34542,20 @@
     "credits": 3.0
   },
   {
+    "code": "PE034",
+    "title": "Boxing",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "PE034C",
     "title": "Dance - Intl Standard Advanced",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "PE035",
-    "title": "Surfing",
+    "code": "PE034",
+    "title": "FitBoxing",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -26772,15 +34572,27 @@
     "credits": 3.0
   },
   {
+    "code": "PE035",
+    "title": "Surfing",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE036",
+    "title": "Canyoneering and Lead Climbing",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "PE036",
     "title": "Outdoor Adventure-Rock Climbing",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "PE037",
-    "title": "Rock Climbing",
-    "campus": "cmc",
+    "code": "PE036",
+    "title": "U-Jam",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -26790,14 +34602,20 @@
     "credits": 3.0
   },
   {
+    "code": "PE037A",
+    "title": "Outdoor Adventure-Rock Climbing",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "PE037B",
     "title": "Dance - Social Intermediate",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "PE038",
-    "title": "Sailing",
+    "code": "PE037",
+    "title": "Rock Climbing",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -26808,8 +34626,8 @@
     "credits": 3.0
   },
   {
-    "code": "PE039",
-    "title": "SCUBA-Beg/Int",
+    "code": "PE038",
+    "title": "Sailing",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -26844,9 +34662,21 @@
     "credits": 3.0
   },
   {
+    "code": "PE039",
+    "title": "SCUBA-Beg/Int",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "PE040",
     "title": "Archery",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE040",
+    "title": "Pickleball",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -26868,14 +34698,14 @@
     "credits": 3.0
   },
   {
-    "code": "PE044",
-    "title": "Diving-Beginning/Intermediate",
+    "code": "PE044A",
+    "title": "Diving-Beginning",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "PE044A",
-    "title": "Diving-Beginning",
+    "code": "PE044",
+    "title": "Diving-Beginning/Intermediate",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -26886,26 +34716,26 @@
     "credits": 3.0
   },
   {
-    "code": "PE046",
-    "title": "Floor Hockey",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "PE046A",
     "title": "Archery Beginning",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "PE047",
-    "title": "Flag Football",
+    "code": "PE046",
+    "title": "Archery",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE046",
+    "title": "Floor Hockey",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "PE048",
-    "title": "Golf",
+    "code": "PE047",
+    "title": "Flag Football",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -26922,9 +34752,27 @@
     "credits": 3.0
   },
   {
+    "code": "PE048",
+    "title": "Badminton",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE048",
+    "title": "Golf",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "PE049",
     "title": "Football-Intermediate/Advanced",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE050",
+    "title": "Bowling",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -26958,20 +34806,14 @@
     "credits": 3.0
   },
   {
-    "code": "PE055",
-    "title": "Roller Hockey",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "PE055A",
     "title": "Fencing I",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "PE056",
-    "title": "Soccer Int/Adv",
+    "code": "PE055",
+    "title": "Roller Hockey",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -26982,6 +34824,24 @@
     "credits": 3.0
   },
   {
+    "code": "PE056",
+    "title": "Fencing II",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE056",
+    "title": "Soccer Int/Adv",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE057",
+    "title": "Field Hockey",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "PE057",
     "title": "Personal Fitness Challenge",
     "campus": "cmc",
@@ -26989,13 +34849,13 @@
   },
   {
     "code": "PE058",
-    "title": "Team Sports",
-    "campus": "cmc",
+    "title": "Flag Football",
+    "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "PE059",
-    "title": "Ping Pong",
+    "code": "PE058",
+    "title": "Team Sports",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -27006,8 +34866,20 @@
     "credits": 3.0
   },
   {
-    "code": "PE060",
-    "title": "Golf",
+    "code": "PE059",
+    "title": "Ping Pong",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE059",
+    "title": "Team Sports",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE060A",
+    "title": "Golf Beginning",
     "campus": "po",
     "credits": 3.0
   },
@@ -27019,14 +34891,32 @@
   },
   {
     "code": "PE060B",
+    "title": "Golf Beginning/Intermediate",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE060B",
     "title": "Tennis-Intermediate",
     "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PE060C",
+    "title": "Golf - Short Game",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE060C",
     "title": "Tennis-Advanced",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE060",
+    "title": "Golf",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -27055,6 +34945,12 @@
   },
   {
     "code": "PE065",
+    "title": "ACE Health Coach - Exam Prep",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE065",
     "title": "ACE Personal Training Certifcatn",
     "campus": "cmc",
     "credits": 3.0
@@ -27066,15 +34962,27 @@
     "credits": 3.0
   },
   {
+    "code": "PE067C",
+    "title": "Racquet Sports",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "PE067",
     "title": "Racquetball",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "PE067C",
-    "title": "Racquet Sports",
-    "campus": "po",
+    "code": "PE067",
+    "title": "Stress Management and Resiliency",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE068",
+    "title": "American Red Cross Lifeguarding",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -27084,8 +34992,14 @@
     "credits": 3.0
   },
   {
-    "code": "PE069",
-    "title": "Core, Cardio, & More",
+    "code": "PE068",
+    "title": "Speed Lacrosse",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE069A",
+    "title": "Core, Cardio, & More (STRONG)",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -27096,9 +35010,15 @@
     "credits": 3.0
   },
   {
-    "code": "PE070",
-    "title": "Bikram Yoga",
+    "code": "PE069",
+    "title": "Core, Cardio, & More",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE069",
+    "title": "Soccer",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -27114,15 +35034,33 @@
     "credits": 3.0
   },
   {
+    "code": "PE070",
+    "title": "Basketball: 3 on 3",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE070",
+    "title": "Bikram Yoga",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE070",
+    "title": "Yoga-Hot Yoga",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "PE071",
     "title": "Bollywood",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "PE072",
-    "title": "Capoeira",
-    "campus": "cmc",
+    "code": "PE071",
+    "title": "Racquets Class",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -27132,9 +35070,15 @@
     "credits": 3.0
   },
   {
-    "code": "PE073",
-    "title": "Intro to Meditation",
+    "code": "PE072",
+    "title": "Capoeira",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE072",
+    "title": "Squash",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -27150,6 +35094,12 @@
     "credits": 3.0
   },
   {
+    "code": "PE073",
+    "title": "Basketball: Full Court 5 on 5",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "PE073C",
     "title": "Mindfulness Meditation",
     "campus": "cmc",
@@ -27162,8 +35112,8 @@
     "credits": 3.0
   },
   {
-    "code": "PE074",
-    "title": "Yoga-Power",
+    "code": "PE073",
+    "title": "Intro to Meditation",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -27174,15 +35124,27 @@
     "credits": 3.0
   },
   {
-    "code": "PE075",
-    "title": "Yoga-Vinyasa Flow",
+    "code": "PE074",
+    "title": "Yoga-Power",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE075A",
+    "title": "Swimming - Beginning",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "PE075A",
     "title": "Yoga-Beg Vinyasa Flow",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE075B",
+    "title": "Swimming - Intermediate",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -27240,8 +35202,8 @@
     "credits": 3.0
   },
   {
-    "code": "PE076",
-    "title": "Yoga-Hatha",
+    "code": "PE075",
+    "title": "Yoga-Vinyasa Flow",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -27252,8 +35214,8 @@
     "credits": 3.0
   },
   {
-    "code": "PE077",
-    "title": "Yoga-Ashtanga",
+    "code": "PE076",
+    "title": "Yoga-Hatha",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -27288,8 +35250,8 @@
     "credits": 3.0
   },
   {
-    "code": "PE078",
-    "title": "Zumba",
+    "code": "PE077",
+    "title": "Yoga-Ashtanga",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -27300,8 +35262,14 @@
     "credits": 3.0
   },
   {
-    "code": "PE079",
-    "title": "Tumbling-Beg",
+    "code": "PE078",
+    "title": "Ultimate Frisbee",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE078",
+    "title": "Zumba",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -27312,9 +35280,33 @@
     "credits": 3.0
   },
   {
+    "code": "PE079",
+    "title": "Tumbling-Beg",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE079",
+    "title": "Volleyball",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE080",
+    "title": "Comm Engagement Lacrosse (CP)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "PE080",
     "title": "Free Weights",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE081",
+    "title": "Plogging",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -27331,8 +35323,32 @@
   },
   {
     "code": "PE083",
+    "title": "Beach Games",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE083",
+    "title": "Beach Games/Lawn Sports",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE083",
     "title": "Weights-Adv/Fitness",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE084A",
+    "title": "Weights-Adv Free Weights",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE084",
+    "title": "Playground Games",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -27342,9 +35358,9 @@
     "credits": 3.0
   },
   {
-    "code": "PE084A",
-    "title": "Weights-Adv Free Weights",
-    "campus": "cmc",
+    "code": "PE085",
+    "title": "Adapted Physical Education",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -27360,9 +35376,27 @@
     "credits": 3.0
   },
   {
+    "code": "PE086",
+    "title": "Baseball Analytics",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE086",
+    "title": "Water Safety/Instructor Cert.",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "PE087",
     "title": "Circuit Training",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE087",
+    "title": "Fitness & Wellness",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -27379,8 +35413,20 @@
   },
   {
     "code": "PE090",
+    "title": "CPR/First Aid",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE090",
     "title": "First Aid/CPR",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE091",
+    "title": "Care & Prev of Athletic Injuries",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -27393,6 +35439,12 @@
     "code": "PE092",
     "title": "CPR/AED & Wilderness First Aid",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE092",
+    "title": "Comm. Emergency Team Response",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -27438,6 +35490,12 @@
     "credits": 3.0
   },
   {
+    "code": "PE110",
+    "title": "Vars Team: Football",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "PE115",
     "title": "Diving Team-Men/Women",
     "campus": "cmc",
@@ -27459,6 +35517,12 @@
     "code": "PE120",
     "title": "Football Team",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE120",
+    "title": "Vars Team: Volleyball",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -27516,15 +35580,15 @@
     "credits": 3.0
   },
   {
-    "code": "PE140",
-    "title": "Soccer Team-Women",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "PE140M",
     "title": "Vars Team: Swim/Diving Men",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE140",
+    "title": "Soccer Team-Women",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -27546,14 +35610,14 @@
     "credits": 3.0
   },
   {
-    "code": "PE152",
-    "title": "Tennis Team-Women",
-    "campus": "cmc",
+    "code": "PE150",
+    "title": "Vars Team: Baseball",
+    "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "PE155",
-    "title": "Track & Field-Men/Women",
+    "code": "PE152",
+    "title": "Tennis Team-Women",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -27564,8 +35628,26 @@
     "credits": 3.0
   },
   {
+    "code": "PE155",
+    "title": "Track & Field-Men/Women",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE155",
+    "title": "Vars Team: Golf",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "PE155W",
     "title": "Vars Team: Golf Women",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE160",
+    "title": "Varsity Team: Lacrosse",
     "campus": "po",
     "credits": 3.0
   },
@@ -27578,6 +35660,12 @@
   {
     "code": "PE160W",
     "title": "Vars Team: Lacrosse Women",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE165",
+    "title": "Vars Team: Softball",
     "campus": "po",
     "credits": 3.0
   },
@@ -27690,6 +35778,12 @@
     "credits": 3.0
   },
   {
+    "code": "PE235",
+    "title": "Soccer Club-Men",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "PE237",
     "title": "Soccer Club-Women",
     "campus": "cmc",
@@ -27744,9 +35838,39 @@
     "credits": 3.0
   },
   {
+    "code": "PE",
+    "title": "PE Waiver",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "PEPFL",
     "title": "Physical Fitness Course",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PE",
+    "title": "Phys Ed Req Fulfilled",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE",
+    "title": "Physical Ed: Directed Readings",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE",
+    "title": "Physical Ed: Indep Research",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE",
+    "title": "Physical Ed: Research Asstship",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -27804,6 +35928,12 @@
     "credits": 3.0
   },
   {
+    "code": "PHIL007",
+    "title": "Introduction to Philosophy",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "PHIL025",
     "title": "Feminist Philosophy",
     "campus": "po",
@@ -27816,15 +35946,39 @@
     "credits": 3.0
   },
   {
+    "code": "PHIL030H",
+    "title": "Honors Intro: Philos Questions",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL030",
+    "title": "Intro to Knowledge, Mind & Exist",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "PHIL030",
     "title": "Intro: Philosophical Questions",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "PHIL030H",
-    "title": "Honors Intro: Philos Questions",
-    "campus": "cmc",
+    "code": "PHIL030",
+    "title": "Knowledge, Mind & Existence",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL030",
+    "title": "Knowledge, Mind, & Existence",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL030",
+    "title": "Social Philosophy",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -27834,15 +35988,15 @@
     "credits": 3.0
   },
   {
-    "code": "PHIL032",
-    "title": "Ethical Theory",
-    "campus": "po",
+    "code": "PHIL031",
+    "title": "History of Ethics",
+    "campus": "pz",
     "credits": 3.0
   },
   {
-    "code": "PHIL033",
-    "title": "Intro: Political Philosophy",
-    "campus": "cmc",
+    "code": "PHIL032",
+    "title": "Ethical Theory",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -27852,9 +36006,27 @@
     "credits": 3.0
   },
   {
+    "code": "PHIL033",
+    "title": "Intro: Political Philosophy",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL033",
+    "title": "Political Philosophy",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "PHIL034",
     "title": "Intro: Moral & Political Issues",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL034",
+    "title": "Philosophy of Law",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -27876,8 +36048,38 @@
     "credits": 3.0
   },
   {
+    "code": "PHIL037",
+    "title": "Values and the Environment",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL038",
+    "title": "Bioethics",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "PHIL038",
     "title": "Intro: Reason and Reality",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL039",
+    "title": "Gender, Crime and Punishment(CP)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL039",
+    "title": "Happiness and the Good Life",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL039",
+    "title": "Intro: Special Topics in Phil",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -27897,6 +36099,12 @@
     "code": "PHIL042",
     "title": "History of Modern Philosophy",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL042",
+    "title": "Modern Philosophy",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -27924,15 +36132,15 @@
     "credits": 3.0
   },
   {
-    "code": "PHIL054",
-    "title": "Existentialism",
-    "campus": "po",
-    "credits": 3.0
-  },
-  {
     "code": "PHIL054A",
     "title": "Existentialism",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL054",
+    "title": "Existentialism",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -28044,6 +36252,12 @@
     "credits": 3.0
   },
   {
+    "code": "PHIL096",
+    "title": "Philosophy of Religion",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "PHIL098",
     "title": "Summer Reading & Research",
     "campus": "po",
@@ -28074,12 +36288,6 @@
     "credits": 3.0
   },
   {
-    "code": "PHIL101",
-    "title": "Hist of Phil:Ancient Philosophy",
-    "campus": "hmc",
-    "credits": 3.0
-  },
-  {
     "code": "PHIL101B",
     "title": "Classical Ethical Theory: Plato",
     "campus": "cmc",
@@ -28098,9 +36306,21 @@
     "credits": 3.0
   },
   {
+    "code": "PHIL101",
+    "title": "Hist of Phil:Ancient Philosophy",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "PHIL102",
     "title": "Hist of Phil: Modern Era",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL102",
+    "title": "Science and Values",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -28110,9 +36330,39 @@
     "credits": 3.0
   },
   {
+    "code": "PHIL103",
+    "title": "Nietzsche",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL103",
+    "title": "Phil of Science: Historical Surv",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL103",
+    "title": "Philosophy of Science: History",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "PHIL104",
     "title": "Hist of Phil:Contemporary Period",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL104",
+    "title": "Phil of Science: Topical Survey",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL104",
+    "title": "Philosophy of Science: Topics",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -28128,9 +36378,21 @@
     "credits": 3.0
   },
   {
+    "code": "PHIL106",
+    "title": "Philosophy of Biology",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "PHIL107",
     "title": "Early Modern Philosophy",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL108",
+    "title": "Hegel",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -28189,6 +36451,12 @@
   },
   {
     "code": "PHIL119",
+    "title": "History of Existentialism",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL119",
     "title": "Medieval Thought",
     "campus": "pz",
     "credits": 3.0
@@ -28203,6 +36471,30 @@
     "code": "PHIL121",
     "title": "Ethical Theory",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL121",
+    "title": "Naturalism and Morality",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL121",
+    "title": "Philosophy of Language",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL121",
+    "title": "Rationalism",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL122",
+    "title": "Continental Phil of Self & Other",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -28224,9 +36516,33 @@
     "credits": 3.0
   },
   {
+    "code": "PHIL124",
+    "title": "Native American Philosophy",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL124",
+    "title": "Schools of Cultural Criticism",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL125",
+    "title": "Classical Chinese Philosophy",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "PHIL125",
     "title": "Ethical Issues in Science/Engr",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL125",
+    "title": "History of the Self",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -28243,6 +36559,12 @@
   },
   {
     "code": "PHIL128",
+    "title": "Practical Rationality",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL128",
     "title": "The Metaphysics of Persons",
     "campus": "cmc",
     "credits": 3.0
@@ -28251,6 +36573,18 @@
     "code": "PHIL129",
     "title": "Contemporary Moral Problems",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL130",
+    "title": "Controversies in Human Evolution",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL130",
+    "title": "Philosophy of Mind",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -28272,6 +36606,12 @@
     "credits": 3.0
   },
   {
+    "code": "PHIL132",
+    "title": "The Substance of the Soul",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "PHIL133",
     "title": "Philosophy of Science",
     "campus": "cmc",
@@ -28279,7 +36619,19 @@
   },
   {
     "code": "PHIL134",
+    "title": "Knowledge and Mind",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL134",
     "title": "Topics: Metaphysics/Epistemology",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL135",
+    "title": "Philosophy of Mind",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -28305,6 +36657,18 @@
     "code": "PHIL138",
     "title": "ClassclLiberalism/Libertarianism",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL138",
+    "title": "Epistemology",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL138",
+    "title": "Intro Phil of Language & Mind",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -28344,6 +36708,12 @@
     "credits": 3.0
   },
   {
+    "code": "PHIL149",
+    "title": "Topics in Philosophy",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "PHIL150",
     "title": "Philosophy of Feminism",
     "campus": "sc",
@@ -28368,12 +36738,6 @@
     "credits": 3.0
   },
   {
-    "code": "PHIL155",
-    "title": "Islam vs. Islam",
-    "campus": "pz",
-    "credits": 3.0
-  },
-  {
     "code": "PHIL155A",
     "title": "Utopian Political Theory(Modern)",
     "campus": "sc",
@@ -28383,6 +36747,18 @@
     "code": "PHIL155B",
     "title": "Utopian Political Theory(Modern)",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL155",
+    "title": "Ethics of Begin & End of Life",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL155",
+    "title": "Islam vs. Islam",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -28401,6 +36777,12 @@
     "code": "PHIL159",
     "title": "Metaethics",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL160",
+    "title": "Ethical Theory",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -28428,6 +36810,18 @@
     "credits": 3.0
   },
   {
+    "code": "PHIL164",
+    "title": "Seminar: The Moral Deal",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL166",
+    "title": "Rationality in Dispute",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "PHIL166",
     "title": "The Social Contract Tradition",
     "campus": "cmc",
@@ -28436,6 +36830,12 @@
   {
     "code": "PHIL167",
     "title": "Moral Psychology",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL168",
+    "title": "Naturalism and Morality",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -28453,6 +36853,12 @@
   },
   {
     "code": "PHIL170",
+    "title": "Faith and Reason",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL170",
     "title": "Great Philosophers",
     "campus": "hmc",
     "credits": 3.0
@@ -28461,12 +36867,6 @@
     "code": "PHIL174",
     "title": "Perspectives on the Senses",
     "campus": "pz",
-    "credits": 3.0
-  },
-  {
-    "code": "PHIL176",
-    "title": "Philosophy of Law",
-    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -28482,6 +36882,12 @@
     "credits": 3.0
   },
   {
+    "code": "PHIL176",
+    "title": "Philosophy of Law",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "PHIL177",
     "title": "Global Ethics",
     "campus": "cmc",
@@ -28491,12 +36897,6 @@
     "code": "PHIL178",
     "title": "Special Topics in Philosophy",
     "campus": "cmc",
-    "credits": 3.0
-  },
-  {
-    "code": "PHIL179",
-    "title": "Special Topics in Philosophy",
-    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -28519,7 +36919,25 @@
   },
   {
     "code": "PHIL179D",
+    "title": "Empirical & Experimental Phil",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL179D",
     "title": "Empirical/ExperimentalPhilosophy",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL179",
+    "title": "Greek Moral Philosophy",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL179",
+    "title": "Special Topics in Philosophy",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -28548,15 +36966,21 @@
     "credits": 3.0
   },
   {
+    "code": "PHIL183",
+    "title": "Philosophy and Literature",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "PHIL184",
     "title": "Topics in Aesthetics",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "PHIL185",
-    "title": "Life, Death, & Survival of Death",
-    "campus": "cmc",
+    "code": "PHIL185A",
+    "title": "Plato",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -28575,6 +36999,18 @@
     "code": "PHIL185L",
     "title": "Topics: Epistem/Metaphysics/Mind",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL185L",
+    "title": "Topics:Epist Metaphysics & Mind",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL185",
+    "title": "Life, Death, & Survival of Death",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -28638,20 +37074,20 @@
     "credits": 3.0
   },
   {
-    "code": "PHIL187",
-    "title": "Phil Roots of European Fascism",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "PHIL187C",
     "title": "Tutorial in Ancient Philosophy",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "PHIL188",
-    "title": "Philosophy thru Science Fiction",
+    "code": "PHIL187",
+    "title": "Environmental Ethics",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL187",
+    "title": "Phil Roots of European Fascism",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -28662,8 +37098,20 @@
     "credits": 3.0
   },
   {
+    "code": "PHIL188",
+    "title": "Philosophy thru Science Fiction",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "PHIL189",
     "title": "Business Ethics",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL190",
+    "title": "Science, Values, and Democracy",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -28674,15 +37122,39 @@
     "credits": 3.0
   },
   {
-    "code": "PHIL191",
-    "title": "Senior Thesis",
-    "campus": "po",
+    "code": "PHIL190",
+    "title": "Senior Seminar in Philosophy",
+    "campus": "sc",
     "credits": 3.0
   },
   {
     "code": "PHIL191B",
     "title": "Accelerated Senior Thesis",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL191",
+    "title": "Race and Policy",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL191",
+    "title": "Senior Thesis",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL191",
+    "title": "Senior Thesis in Philosophy",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL197",
+    "title": "Directed Reading",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -28698,9 +37170,15 @@
     "credits": 3.0
   },
   {
-    "code": "PHIL199",
-    "title": "Independent Study in Philosophy",
-    "campus": "cmc",
+    "code": "PHIL198",
+    "title": "Independent Internship",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL198",
+    "title": "Summer Reading & Research",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -28713,6 +37191,12 @@
     "code": "PHIL199IRPO",
     "title": "Philosophy: Independent Research",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL199",
+    "title": "Independent Study in Philosophy",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -28764,12 +37248,6 @@
     "credits": 3.0
   },
   {
-    "code": "PHIL335",
-    "title": "Logic I",
-    "campus": "cgu",
-    "credits": 3.0
-  },
-  {
     "code": "PHIL335A",
     "title": "Logic",
     "campus": "cgu",
@@ -28778,6 +37256,12 @@
   {
     "code": "PHIL335B",
     "title": "Logic II",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "PHIL335",
+    "title": "Logic I",
     "campus": "cgu",
     "credits": 3.0
   },
@@ -28861,6 +37345,12 @@
   },
   {
     "code": "PHYS003",
+    "title": "Lab, Physics of Music",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PHYS003",
     "title": "The Physics of Music",
     "campus": "po",
     "credits": 3.0
@@ -28908,15 +37398,21 @@
     "credits": 3.0
   },
   {
+    "code": "PHYS024A",
+    "title": "Mechanics & Wave Motion",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "PHYS024",
     "title": "Mechanics & Wave Motion",
     "campus": "hmc",
     "credits": 3.0
   },
   {
-    "code": "PHYS024A",
-    "title": "Mechanics & Wave Motion",
-    "campus": "hmc",
+    "code": "PHYS030L",
+    "title": "General Physics",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -28932,9 +37428,9 @@
     "credits": 3.0
   },
   {
-    "code": "PHYS031",
-    "title": "What's the Matter?",
-    "campus": "hmc",
+    "code": "PHYS031L",
+    "title": "General Physics",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -28947,6 +37443,12 @@
     "code": "PHYS031LXKS",
     "title": "General Physics Lab",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHYS031",
+    "title": "What's the Matter?",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -28992,15 +37494,21 @@
     "credits": 3.0
   },
   {
+    "code": "PHYS041",
+    "title": "Lab, General Physics",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "PHYS042",
     "title": "General Physics w/Lab",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "PHYS049",
-    "title": "Special Topics in Physics",
-    "campus": "hmc",
+    "code": "PHYS042",
+    "title": "Lab, General Physics",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -29016,14 +37524,20 @@
     "credits": 3.0
   },
   {
-    "code": "PHYS050",
-    "title": "Physics Laboratory",
+    "code": "PHYS049",
+    "title": "Special Topics in Physics",
     "campus": "hmc",
     "credits": 3.0
   },
   {
-    "code": "PHYS051",
-    "title": "Electromagnetic Theory & Optics",
+    "code": "PHYS050",
+    "title": "Core Physics Laboratory",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHYS050",
+    "title": "Physics Laboratory",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -29046,14 +37560,14 @@
     "credits": 3.0
   },
   {
-    "code": "PHYS051M",
-    "title": "Elctrmagnetic Thry & Vector Calc",
+    "code": "PHYS051",
+    "title": "Electromagnetic Theory & Optics",
     "campus": "hmc",
     "credits": 3.0
   },
   {
-    "code": "PHYS052",
-    "title": "Quantum Physics",
+    "code": "PHYS051M",
+    "title": "Elctrmagnetic Thry & Vector Calc",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -29061,6 +37575,12 @@
     "code": "PHYS052L",
     "title": "Weapons of Mass Destruction",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHYS052",
+    "title": "Quantum Physics",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -29073,6 +37593,12 @@
     "code": "PHYS058L",
     "title": "What's the Matter",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHYS070",
+    "title": "Lab, Spacetime, Quanta, Entropy",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -29136,13 +37662,13 @@
     "credits": 3.0
   },
   {
-    "code": "PHYS080",
+    "code": "PHYS080S",
     "title": "Topics in Physics",
     "campus": "hmc",
     "credits": 3.0
   },
   {
-    "code": "PHYS080S",
+    "code": "PHYS080",
     "title": "Topics in Physics",
     "campus": "hmc",
     "credits": 3.0
@@ -29161,6 +37687,12 @@
   },
   {
     "code": "PHYS100",
+    "title": "Computational Phys/Engineering",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHYS100",
     "title": "Computatnl Physics+Engineering",
     "campus": "sc",
     "credits": 3.0
@@ -29169,6 +37701,18 @@
     "code": "PHYS101",
     "title": "Classical Mechns Computal Appls",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHYS101",
+    "title": "Foundatns of Modern Phys w/Lab",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PHYS101",
+    "title": "Lab, Foundations Modern Physics",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -29250,6 +37794,18 @@
     "credits": 3.0
   },
   {
+    "code": "PHYS128",
+    "title": "Electronics with Laboratory (CP)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PHYS128",
+    "title": "Lab, Electronics",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "PHYS133",
     "title": "Electronics Laboratory",
     "campus": "hmc",
@@ -29301,6 +37857,12 @@
     "code": "PHYS154",
     "title": "Fields & Waves",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHYS155",
+    "title": "Experimental Optics",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -29364,6 +37926,12 @@
     "credits": 3.0
   },
   {
+    "code": "PHYS170",
+    "title": "Quantum Mechanics",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "PHYS172",
     "title": "General Relativity & Cosmology",
     "campus": "hmc",
@@ -29371,8 +37939,26 @@
   },
   {
     "code": "PHYS174",
+    "title": "Biolocomotion",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHYS174",
     "title": "Biophysics",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHYS174",
+    "title": "Contemporary Experimental Phys",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PHYS174",
+    "title": "Lab, Contemp Experimental Phys",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -29388,12 +37974,6 @@
     "credits": 3.0
   },
   {
-    "code": "PHYS178",
-    "title": "Special Topics in Physics",
-    "campus": "hmc",
-    "credits": 3.0
-  },
-  {
     "code": "PHYS178A",
     "title": "Mater Sci of Energy Conv & Stor",
     "campus": "hmc",
@@ -29403,6 +37983,12 @@
     "code": "PHYS178B",
     "title": "Solid State Physics II",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHYS178",
+    "title": "Biophysics",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -29426,6 +38012,12 @@
   {
     "code": "PHYS178F",
     "title": "Computational Physics",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHYS178",
+    "title": "Special Topics in Physics",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -29472,14 +38064,14 @@
     "credits": 3.0
   },
   {
-    "code": "PHYS187",
-    "title": "Special Topics in Physics",
+    "code": "PHYS187A",
+    "title": "Topics: Synchrotron Radiation",
     "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "PHYS187A",
-    "title": "Topics: Synchrotron Radiation",
+    "code": "PHYS187",
+    "title": "Special Topics in Physics",
     "campus": "sc",
     "credits": 3.0
   },
@@ -29496,21 +38088,15 @@
     "credits": 3.0
   },
   {
-    "code": "PHYS190",
-    "title": "Senior Seminar",
-    "campus": "po",
-    "credits": 3.0
-  },
-  {
     "code": "PHYS190L",
     "title": "Sr Thes Rsrch Proj Phys-2nd Sem",
     "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "PHYS191",
-    "title": "Research in Physics",
-    "campus": "hmc",
+    "code": "PHYS190",
+    "title": "Senior Seminar",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -29526,6 +38112,24 @@
     "credits": 3.0
   },
   {
+    "code": "PHYS191",
+    "title": "One-Semester Thesis in Physics",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHYS191",
+    "title": "Research in Physics",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHYS191",
+    "title": "Senior Thesis",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "PHYS192",
     "title": "Research in Physics",
     "campus": "hmc",
@@ -29535,6 +38139,12 @@
     "code": "PHYS193",
     "title": "Physics Clinic",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHYS193",
+    "title": "Senior Comprehensive Examination",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -29563,14 +38173,20 @@
   },
   {
     "code": "PHYS198",
+    "title": "Independent Internship: Physics",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PHYS198",
     "title": "Readings in Physics",
     "campus": "hmc",
     "credits": 3.0
   },
   {
-    "code": "PHYS199",
-    "title": "Senior Thesis in Physics",
-    "campus": "hmc",
+    "code": "PHYS198",
+    "title": "Summer Reading & Research",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -29586,6 +38202,12 @@
     "credits": 3.0
   },
   {
+    "code": "PHYS199",
+    "title": "Independent Study in Physics",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "PHYS199L",
     "title": "Adv. Lab Skill-Set Physics",
     "campus": "sc",
@@ -29598,15 +38220,15 @@
     "credits": 3.0
   },
   {
-    "code": "PHYSELECTHM",
-    "title": "Physics Major Elective",
+    "code": "PHYS199",
+    "title": "Senior Thesis in Physics",
     "campus": "hmc",
     "credits": 3.0
   },
   {
-    "code": "POLI",
-    "title": "DEMOCRACY, HUMAN RIGHTS AND USFP",
-    "campus": "po",
+    "code": "PHYSELECTHM",
+    "title": "Physics Major Elective",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -29634,14 +38256,20 @@
     "credits": 3.0
   },
   {
-    "code": "POLI005",
-    "title": "Intro to Comparative Politics",
+    "code": "POLI003",
+    "title": "Lab, Intro to American Politics",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "POLI005/SI",
     "title": "Speaking Intensive Option Taken",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "POLI005",
+    "title": "Intro to Comparative Politics",
     "campus": "po",
     "credits": 3.0
   },
@@ -29821,6 +38449,12 @@
   },
   {
     "code": "POLI098",
+    "title": "Political Journalism",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "POLI098",
     "title": "Summer Reading & Research",
     "campus": "po",
     "credits": 3.0
@@ -29886,15 +38520,51 @@
     "credits": 3.0
   },
   {
+    "code": "POLI111",
+    "title": "Politics & Markets:Latin America",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "POLI112",
+    "title": "Ethnic Conflict",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "POLI112",
     "title": "Hannah Arendt",
     "campus": "po",
     "credits": 3.0
   },
   {
+    "code": "POLI112",
+    "title": "Mobilizing Islam",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "POLI113",
+    "title": "People& Power Modern Middle East",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "POLI113",
+    "title": "People/Power Modern Middle East",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "POLI113",
     "title": "Politics of Comedy",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "POLI114",
+    "title": "Islam & Politics in Middle East",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -29910,9 +38580,27 @@
     "credits": 3.0
   },
   {
+    "code": "POLI115",
+    "title": "Politics of Identity-India",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "POLI115",
+    "title": "Politics of Identity-South Asia",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "POLI116",
     "title": "American Road Trip",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "POLI116",
+    "title": "The Politics of God",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -29934,14 +38622,26 @@
     "credits": 3.0
   },
   {
+    "code": "POLI120IOSC",
+    "title": "Intro to U.S. Politics",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "POLI120",
     "title": "Intro to American Politics",
     "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "POLI120IOSC",
+    "code": "POLI120",
     "title": "Intro to U.S. Politics",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "POLI121",
+    "title": "Conservative Political Thought",
     "campus": "sc",
     "credits": 3.0
   },
@@ -29952,19 +38652,25 @@
     "credits": 3.0
   },
   {
+    "code": "POLI121",
+    "title": "Ending Mass Incarceration",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "POLI122",
     "title": "The Power Elite",
     "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "POLI124",
+    "code": "POLI124IOSC",
     "title": "Race in American Politics",
     "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "POLI124IOSC",
+    "code": "POLI124",
     "title": "Race in American Politics",
     "campus": "sc",
     "credits": 3.0
@@ -30006,14 +38712,32 @@
     "credits": 3.0
   },
   {
+    "code": "POLI130",
+    "title": "Intro to Political Economy",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "POLI131",
     "title": "American Presidency",
     "campus": "po",
     "credits": 3.0
   },
   {
+    "code": "POLI131",
+    "title": "Political Economy of Law",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "POLI132",
     "title": "Wealth, Poverty, and Inequality",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "POLI133",
+    "title": "Emerging Econ of Europe & Asia",
     "campus": "sc",
     "credits": 3.0
   },
@@ -30030,12 +38754,6 @@
     "credits": 3.0
   },
   {
-    "code": "POLI135",
-    "title": "Policy Implementation/Evaluation",
-    "campus": "po",
-    "credits": 3.0
-  },
-  {
     "code": "POLI135IOSC",
     "title": "Political Economy of Food",
     "campus": "sc",
@@ -30044,6 +38762,18 @@
   {
     "code": "POLI135L",
     "title": "Political Economy of Food Lab",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "POLI135",
+    "title": "Policy Implementation/Evaluation",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "POLI135",
+    "title": "Political Economy of Food",
     "campus": "sc",
     "credits": 3.0
   },
@@ -30074,6 +38804,18 @@
   {
     "code": "POLI141",
     "title": "Corpns & Govts",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "POLI141",
+    "title": "Politics of Race & Amer Pop Film",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "POLI142",
+    "title": "Anti-Democracy in America",
     "campus": "po",
     "credits": 3.0
   },
@@ -30114,6 +38856,12 @@
     "credits": 3.0
   },
   {
+    "code": "POLI149",
+    "title": "Sci, Tech & Public Policy",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "POLI150",
     "title": "Intro to Public Policy",
     "campus": "sc",
@@ -30121,8 +38869,20 @@
   },
   {
     "code": "POLI151",
+    "title": "PostWestphalia",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "POLI151",
     "title": "Women and Public Policy",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "POLI152",
+    "title": "Political Dialogue & Resistance",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -30169,6 +38929,12 @@
   },
   {
     "code": "POLI160",
+    "title": "Comparative European Politics",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "POLI160",
     "title": "Comparative Politics of Europe",
     "campus": "po",
     "credits": 3.0
@@ -30183,6 +38949,12 @@
     "code": "POLI162",
     "title": "Comparative Politics of Africa",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "POLI162",
+    "title": "Political Philosophy",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -30212,6 +38984,12 @@
   {
     "code": "POLI167",
     "title": "Arab Spring & Remaking Mid East",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "POLI168",
+    "title": "Int'l Relations of East Asia",
     "campus": "po",
     "credits": 3.0
   },
@@ -30278,12 +39056,6 @@
   {
     "code": "POLI180",
     "title": "Research Design",
-    "campus": "sc",
-    "credits": 3.0
-  },
-  {
-    "code": "POLI187",
-    "title": "Special Topics in Poli+Intl Rel",
     "campus": "sc",
     "credits": 3.0
   },
@@ -30362,6 +39134,18 @@
   {
     "code": "POLI187P",
     "title": "Pol Geog:Politics in Space+Place",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "POLI187",
+    "title": "Special Topics in Poli+Intl Rel",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "POLI187",
+    "title": "Special Topics in Politics",
     "campus": "sc",
     "credits": 3.0
   },
@@ -30462,26 +39246,20 @@
     "credits": 3.0
   },
   {
-    "code": "POLI190",
-    "title": "Senior Seminar",
-    "campus": "sc",
-    "credits": 3.0
-  },
-  {
     "code": "POLI190A",
     "title": "Senior Sem: American Politics",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "POLI190B",
-    "title": "Sr Sem: Comparativ/Intl Politics",
+    "code": "POLI190B/WI",
+    "title": "Writing Intensive Option Taken",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "POLI190B/WI",
-    "title": "Writing Intensive Option Taken",
+    "code": "POLI190B",
+    "title": "Sr Sem: Comparativ/Intl Politics",
     "campus": "po",
     "credits": 3.0
   },
@@ -30498,9 +39276,21 @@
     "credits": 3.0
   },
   {
+    "code": "POLI190",
+    "title": "Senior Seminar",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "POLI191",
     "title": "Senior Thesis",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "POLI191",
+    "title": "Sr Thesis: Politics",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -30516,14 +39306,26 @@
     "credits": 3.0
   },
   {
+    "code": "POLI195A",
+    "title": "Politics Practicum:Food Justice",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "POLI195",
+    "title": "Euro Union Student Scholars Sem",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "POLI195",
     "title": "Subfield Specialization",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "POLI195A",
-    "title": "Politics Practicum:Food Justice",
+    "code": "POLI198I",
+    "title": "Washington Center Internship",
     "campus": "sc",
     "credits": 3.0
   },
@@ -30534,20 +39336,8 @@
     "credits": 3.0
   },
   {
-    "code": "POLI198I",
-    "title": "Washington Center Internship",
-    "campus": "sc",
-    "credits": 3.0
-  },
-  {
     "code": "POLI198S",
     "title": "Washington Center Seminar",
-    "campus": "sc",
-    "credits": 3.0
-  },
-  {
-    "code": "POLI199",
-    "title": "Independent Study: Politics",
     "campus": "sc",
     "credits": 3.0
   },
@@ -30564,8 +39354,32 @@
     "credits": 3.0
   },
   {
+    "code": "POLI199",
+    "title": "Indep St: Politics",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "POLI199",
+    "title": "Indep St: Politics & Intl Rel",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "POLI199",
+    "title": "Independent Study: Politics",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "POLI199RAPO",
     "title": "Politics: Research Asstship",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "POLI",
+    "title": "DEMOCRACY, HUMAN RIGHTS AND USFP",
     "campus": "po",
     "credits": 3.0
   },
@@ -30577,8 +39391,20 @@
   },
   {
     "code": "PORT001",
+    "title": "Introductory Portuguese 1",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PORT001",
     "title": "Introductory Portuguese I",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PORT002",
+    "title": "Introductory Portuguese 2",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -30591,6 +39417,12 @@
     "code": "PORT022",
     "title": "Intensive Intro Portuguese",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PORT022",
+    "title": "Intensive Introductry Portuguese",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -30624,12 +39456,6 @@
     "credits": 3.0
   },
   {
-    "code": "POST010",
-    "title": "Intro to Political Studies",
-    "campus": "pz",
-    "credits": 3.0
-  },
-  {
     "code": "POST010A",
     "title": "Intro to Political Studies",
     "campus": "pz",
@@ -30642,14 +39468,32 @@
     "credits": 3.0
   },
   {
+    "code": "POST010",
+    "title": "Intro to Political Studies",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "POST020",
     "title": "American Politics",
     "campus": "pz",
     "credits": 3.0
   },
   {
+    "code": "POST020",
+    "title": "US Politics: Resistnce & Transfr",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "POST030",
     "title": "Comparative Politics",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "POST030",
+    "title": "Intro to Comparative Politics",
     "campus": "pz",
     "credits": 3.0
   },
@@ -30674,6 +39518,12 @@
   {
     "code": "POST050",
     "title": "Politial Thought East&West Intro",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "POST050",
+    "title": "Politic Thought East&West Intro",
     "campus": "pz",
     "credits": 3.0
   },
@@ -30733,6 +39583,12 @@
   },
   {
     "code": "POST100",
+    "title": "Congress and the Presidency",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "POST100",
     "title": "Legislative Process & Policy",
     "campus": "pz",
     "credits": 3.0
@@ -30740,6 +39596,12 @@
   {
     "code": "POST101",
     "title": "US Campaigns and Elections",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "POST102",
+    "title": "Women and Public Policy",
     "campus": "pz",
     "credits": 3.0
   },
@@ -30756,12 +39618,6 @@
     "credits": 3.0
   },
   {
-    "code": "POST104",
-    "title": "Parties and Campaigns",
-    "campus": "pz",
-    "credits": 3.0
-  },
-  {
     "code": "POST104A",
     "title": "Campaigns and Parties Practicum",
     "campus": "pz",
@@ -30770,6 +39626,12 @@
   {
     "code": "POST104B",
     "title": "Campaigns and Parties Practicum",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "POST104",
+    "title": "Parties and Campaigns",
     "campus": "pz",
     "credits": 3.0
   },
@@ -30804,14 +39666,20 @@
     "credits": 3.0
   },
   {
+    "code": "POST110A",
+    "title": "Politics of the European Union",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "POST110",
     "title": "Government and Pol of the EU",
     "campus": "pz",
     "credits": 3.0
   },
   {
-    "code": "POST110A",
-    "title": "Politics of the European Union",
+    "code": "POST110",
+    "title": "Politcl Campgn & Mobilztn Stratg",
     "campus": "pz",
     "credits": 3.0
   },
@@ -30828,14 +39696,14 @@
     "credits": 3.0
   },
   {
-    "code": "POST113",
-    "title": "Intro to South Asian Politics",
+    "code": "POST113A",
+    "title": "Comparative Immigration Politics",
     "campus": "pz",
     "credits": 3.0
   },
   {
-    "code": "POST113A",
-    "title": "Comparative Immigration Politics",
+    "code": "POST113",
+    "title": "Intro to South Asian Politics",
     "campus": "pz",
     "credits": 3.0
   },
@@ -30843,6 +39711,24 @@
     "code": "POST114",
     "title": "Compar Environmental Politics",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "POST114",
+    "title": "Contemp Leftist Pol in Latin Am",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "POST114",
+    "title": "The Politics of Southeast Asia",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "POST115",
+    "title": "Challenges for Dev Democracies",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -30866,6 +39752,12 @@
   {
     "code": "POST118",
     "title": "Teaching & Politics: Praticum",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "POST118",
+    "title": "The Criminlztn of Latns & Resist",
     "campus": "pz",
     "credits": 3.0
   },
@@ -30895,7 +39787,19 @@
   },
   {
     "code": "POST123",
+    "title": "Building Political Parties",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "POST123",
     "title": "Post-Soviet Politics",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "POST124",
+    "title": "Chinese Politics",
     "campus": "pz",
     "credits": 3.0
   },
@@ -30906,8 +39810,20 @@
     "credits": 3.0
   },
   {
+    "code": "POST124",
+    "title": "Int'l Relations of N.E. Asia",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "POST125",
     "title": "African Politics",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "POST125",
+    "title": "Islam and Politics",
     "campus": "pz",
     "credits": 3.0
   },
@@ -30956,6 +39872,12 @@
   {
     "code": "POST133",
     "title": "Film, Politics and the Cold War",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "POST134",
+    "title": "Authoritarian Politics",
     "campus": "pz",
     "credits": 3.0
   },
@@ -31188,6 +40110,12 @@
     "credits": 3.0
   },
   {
+    "code": "POST174",
+    "title": "US Immigration Policy",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "POST175",
     "title": "Immigration and Race in America",
     "campus": "pz",
@@ -31197,12 +40125,6 @@
     "code": "POST176",
     "title": "Environmental Policy",
     "campus": "pz",
-    "credits": 3.0
-  },
-  {
-    "code": "POST179",
-    "title": "Spec Topics: Political Studies",
-    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -31218,6 +40140,12 @@
     "credits": 3.0
   },
   {
+    "code": "POST179",
+    "title": "Spec Topics: Political Studies",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "POST180",
     "title": "Secularism and Public Opinion",
     "campus": "pz",
@@ -31226,6 +40154,12 @@
   {
     "code": "POST181",
     "title": "Agriculture/Political Rebellion",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "POST182",
+    "title": "Local Democracy",
     "campus": "pz",
     "credits": 3.0
   },
@@ -31248,8 +40182,8 @@
     "credits": 3.0
   },
   {
-    "code": "POST185",
-    "title": "Information Revolutions x.0&z.0",
+    "code": "POST185A",
+    "title": "Logics of Political Auth",
     "campus": "pz",
     "credits": 3.0
   },
@@ -31266,6 +40200,12 @@
     "credits": 3.0
   },
   {
+    "code": "POST185",
+    "title": "Information Revolutions x.0&z.0",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "POST186",
     "title": "Technology and Politics",
     "campus": "pz",
@@ -31278,14 +40218,20 @@
     "credits": 3.0
   },
   {
+    "code": "POST188A",
+    "title": "International Studies Colloquium",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "POST188",
     "title": "Political Innovation",
     "campus": "hmc",
     "credits": 3.0
   },
   {
-    "code": "POST188A",
-    "title": "International Studies Colloquium",
+    "code": "POST188",
+    "title": "The Olympics: History & Politics",
     "campus": "pz",
     "credits": 3.0
   },
@@ -31320,14 +40266,14 @@
     "credits": 3.0
   },
   {
-    "code": "POST194",
-    "title": "International Studies Workshop",
+    "code": "POST193",
+    "title": "The Celtic Tiger",
     "campus": "pz",
     "credits": 3.0
   },
   {
-    "code": "POST195",
-    "title": "Sr Sem: Politics of Homelessness",
+    "code": "POST194",
+    "title": "International Studies Workshop",
     "campus": "pz",
     "credits": 3.0
   },
@@ -31344,8 +40290,32 @@
     "credits": 3.0
   },
   {
+    "code": "POST195",
+    "title": "Sr Sem: Logics of Political Auth",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "POST195",
+    "title": "Sr Sem: Politics of Homelessness",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "POST195",
+    "title": "Sr Sem: Women in Politics",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "POST196",
     "title": "U.S. Presidency & War on Terror",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "POST197G",
+    "title": "Rethinking Radicalism",
     "campus": "pz",
     "credits": 3.0
   },
@@ -31356,14 +40326,14 @@
     "credits": 3.0
   },
   {
-    "code": "POST197G",
-    "title": "Rethinking Radicalism",
+    "code": "POST197",
+    "title": "Science, Politics & Alt Medicine",
     "campus": "pz",
     "credits": 3.0
   },
   {
-    "code": "POST198",
-    "title": "God in the Barrio",
+    "code": "POST198C",
+    "title": "SR Sem: US Im Plcy & Trnstl Poli",
     "campus": "pz",
     "credits": 3.0
   },
@@ -31376,6 +40346,18 @@
   {
     "code": "POST198D",
     "title": "Senior Semnr: Civil Disobedience",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "POST198",
+    "title": "God in the Barrio",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "POST198",
+    "title": "Reproductive Rights",
     "campus": "pz",
     "credits": 3.0
   },
@@ -31440,12 +40422,6 @@
     "credits": 3.0
   },
   {
-    "code": "PP319",
-    "title": "Theories of American Democracy",
-    "campus": "cgu",
-    "credits": 3.0
-  },
-  {
     "code": "PP319B",
     "title": "Amer Poli: Persp in Judicial Pwr",
     "campus": "cgu",
@@ -31454,6 +40430,12 @@
   {
     "code": "PP319D",
     "title": "The President & Nat'l Security",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "PP319",
+    "title": "Theories of American Democracy",
     "campus": "cgu",
     "credits": 3.0
   },
@@ -31614,14 +40596,14 @@
     "credits": 3.0
   },
   {
-    "code": "PP458",
-    "title": "Machiavelli's Discourses on Livy",
+    "code": "PP458A",
+    "title": "Machiavelli's Discourses in Livy",
     "campus": "cgu",
     "credits": 3.0
   },
   {
-    "code": "PP458A",
-    "title": "Machiavelli's Discourses in Livy",
+    "code": "PP458",
+    "title": "Machiavelli's Discourses on Livy",
     "campus": "cgu",
     "credits": 3.0
   },
@@ -31638,14 +40620,14 @@
     "credits": 3.0
   },
   {
-    "code": "PP466",
-    "title": "Plato's Republic",
+    "code": "PP466A",
+    "title": "Plato's Sophist & Statesman\"\"",
     "campus": "cgu",
     "credits": 3.0
   },
   {
-    "code": "PP466A",
-    "title": "Plato's Sophist & Statesman\"\"",
+    "code": "PP466",
+    "title": "Plato's Republic",
     "campus": "cgu",
     "credits": 3.0
   },
@@ -31692,12 +40674,6 @@
     "credits": 3.0
   },
   {
-    "code": "PPA",
-    "title": "Pub Pol Analysis: Dir Readings",
-    "campus": "po",
-    "credits": 3.0
-  },
-  {
     "code": "PPA001",
     "title": "Intro to Public Policy Analysis",
     "campus": "po",
@@ -31722,14 +40698,26 @@
     "credits": 3.0
   },
   {
+    "code": "PPA191",
+    "title": "Sr Thes: Public Policy Analysis",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "PPA195",
     "title": "Internship in Public Affairs",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "PPE",
-    "title": "Phil/Poli/Econ:Directed Readings",
+    "code": "PPA",
+    "title": "Pub Pol Analysis: Dir Readings",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PPA",
+    "title": "Pub Pol Analysis: Indep Research",
     "campus": "po",
     "credits": 3.0
   },
@@ -31770,14 +40758,14 @@
     "credits": 3.0
   },
   {
-    "code": "PPE160",
-    "title": "Freedom, Markets, & Well-Being",
+    "code": "PPE160/WI",
+    "title": "PPE 160-Writing Intensive Optio",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "PPE160/WI",
-    "title": "PPE 160-Writing Intensive Optio",
+    "code": "PPE160",
+    "title": "Freedom, Markets, & Well-Being",
     "campus": "po",
     "credits": 3.0
   },
@@ -31800,6 +40788,18 @@
     "credits": 3.0
   },
   {
+    "code": "PPE",
+    "title": "Phil/Poli/Econ: Indep Research",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PPE",
+    "title": "Phil/Poli/Econ:Directed Readings",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC010",
     "title": "Introduction to Psychology",
     "campus": "pz",
@@ -31808,6 +40808,12 @@
   {
     "code": "PSYC012",
     "title": "Intro African Amer Psychology",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC012",
+    "title": "Intro African American Psych",
     "campus": "pz",
     "credits": 3.0
   },
@@ -31896,9 +40902,9 @@
     "credits": 3.0
   },
   {
-    "code": "PSYC091",
-    "title": "Psychological Statistics",
-    "campus": "pz",
+    "code": "PSYC084",
+    "title": "Psychology of the Chicanx-Latinx",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -31914,9 +40920,9 @@
     "credits": 3.0
   },
   {
-    "code": "PSYC092",
-    "title": "Social Psychology",
-    "campus": "cmc",
+    "code": "PSYC091",
+    "title": "Psychological Statistics",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -31932,6 +40938,18 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC092",
+    "title": "Research Methods",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC092",
+    "title": "Social Psychology",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC093",
     "title": "Political Psychology",
     "campus": "cmc",
@@ -31941,6 +40959,12 @@
     "code": "PSYC095",
     "title": "Foundations of Neuroscience",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC096",
+    "title": "Introduction to Matlab",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -31980,15 +41004,27 @@
     "credits": 3.0
   },
   {
-    "code": "PSYC103",
-    "title": "Social Psychology",
-    "campus": "pz",
+    "code": "PSYC102",
+    "title": "Psychology of Women",
+    "campus": "sc",
     "credits": 3.0
   },
   {
     "code": "PSYC103L",
     "title": "Psych Statistics Lab",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC103",
+    "title": "Psychological Statistics",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC103",
+    "title": "Social Psychology",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -32004,14 +41040,38 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC104L",
+    "title": "Research Design in Psyc Lab",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC104",
+    "title": "Research Design in Psychology",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC105A",
+    "title": "Child Development",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC105",
     "title": "Child Development",
     "campus": "pz",
     "credits": 3.0
   },
   {
-    "code": "PSYC105A",
-    "title": "Child Development",
+    "code": "PSYC105",
+    "title": "Personality",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC106",
+    "title": "Adolescent Development",
     "campus": "pz",
     "credits": 3.0
   },
@@ -32025,6 +41085,24 @@
     "code": "PSYC107",
     "title": "Neuroeconomics",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC107",
+    "title": "Theories of Personality",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC108",
+    "title": "Child Development",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC108",
+    "title": "Drugs: Brain, Mind & Culture",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -32046,9 +41124,27 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC109",
+    "title": "Laboratory in Social Development",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC109",
+    "title": "Psychology of Work and Family",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC110",
-    "title": "Research Methods",
-    "campus": "cmc",
+    "title": "Child Development",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC110",
+    "title": "Laboratory in Child Development",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -32058,8 +41154,20 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC110",
+    "title": "Research Methods",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC111",
-    "title": "Physiological Psychology",
+    "title": "Adolescent Development",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC111L",
+    "title": "Physiological Psychology Lab",
     "campus": "pz",
     "credits": 3.0
   },
@@ -32076,6 +41184,18 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC111",
+    "title": "Physiological Psychology",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC112",
+    "title": "Adult Development and Aging",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC112",
     "title": "Senior Research Methods",
     "campus": "pz",
@@ -32088,8 +41208,20 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC113",
+    "title": "Psychobiology of Emotion",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC114",
     "title": "Human Neuropsychology",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC115",
+    "title": "Ethics and the Brain",
     "campus": "pz",
     "credits": 3.0
   },
@@ -32101,14 +41233,38 @@
   },
   {
     "code": "PSYC116",
+    "title": "Identity Dev in Minority Childrn",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC116",
     "title": "Psyc of Child, Family & Work",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC116",
+    "title": "Risk and Resilience",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC117",
+    "title": "Children & Families: South Asia",
+    "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "PSYC117",
     "title": "Pract in Mediation & Dispute Res",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC118",
+    "title": "Health Psychology",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -32124,6 +41280,18 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC119",
+    "title": "Topics in Developmental Psych",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC120",
+    "title": "Cognitive Development",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC120",
     "title": "Sem:Behavr Modification w/Pract",
     "campus": "cmc",
@@ -32136,14 +41304,44 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC121",
+    "title": "Language and the Brain",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC122",
+    "title": "Cognitive Psychology",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC122L",
+    "title": "Cognitive Psychology Laboratory",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC122",
+    "title": "Research: An Apprenticeship Prog",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC122",
     "title": "Sem:Development Psyc w/Practicum",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "PSYC122L",
-    "title": "Cognitive Psychology Laboratory",
+    "code": "PSYC123",
+    "title": "Cognitive Neuroscience",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC123L",
+    "title": "Cognitive Neuroscience Lab",
     "campus": "sc",
     "credits": 3.0
   },
@@ -32154,9 +41352,9 @@
     "credits": 3.0
   },
   {
-    "code": "PSYC123L",
-    "title": "Cognitive Neuroscience Lab",
-    "campus": "sc",
+    "code": "PSYC123",
+    "title": "Psychology and Language",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -32166,9 +41364,21 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC124",
+    "title": "The Psychology of Fatherhood",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC125",
     "title": "Culture/Hum Dev:African Diaspora",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC125",
+    "title": "Developmental Cog Neuroscience",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -32178,14 +41388,44 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC126",
+    "title": "Language Acquisition",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC126",
+    "title": "Music Cognition",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC127",
     "title": "Language & Cognition",
     "campus": "pz",
     "credits": 3.0
   },
   {
+    "code": "PSYC127",
+    "title": "Neuroscience of Decision Making",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC128",
     "title": "Abnormal Psychology",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC128",
+    "title": "Cognitive Film Studies",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC128",
+    "title": "Psychological Disorders",
     "campus": "sc",
     "credits": 3.0
   },
@@ -32196,15 +41436,39 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC129",
+    "title": "Social Neuroscience",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC130",
     "title": "Controversies in Human Evolution",
     "campus": "pz",
     "credits": 3.0
   },
   {
+    "code": "PSYC130",
+    "title": "Emotion:Persp Exp Psyc & Neuro",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC130",
+    "title": "Stereotyping and Prejudice",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC131",
-    "title": "Special Topics in Psychology",
-    "campus": "cmc",
+    "title": "Clinical Neuropsychology",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC131",
+    "title": "Cognitive Neuroscience",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -32214,9 +41478,63 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC131",
+    "title": "Psychological Disorders",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC131",
+    "title": "Special Topics in Psychology",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC131",
+    "title": "Women and Leadership",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC132",
+    "title": "Autism Spectrum",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC132",
+    "title": "Developmental Psychopathology",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC132",
+    "title": "Intercultural Communications",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC132",
     "title": "Personality Psychology",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC132",
+    "title": "Psychology of Fashion",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC133",
+    "title": "Emotions & Positive Psychology",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC133",
+    "title": "Fldwrk in Clinical Psych (CP)",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -32232,6 +41550,18 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC135",
+    "title": "Human Trafficking Overview",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC135",
+    "title": "Personality Psychology",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC137",
     "title": "Psych of Addictive Behaviors",
     "campus": "po",
@@ -32244,9 +41574,33 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC138",
+    "title": "Hist and Sci of Innateness",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC140",
     "title": "Leadership",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC140",
+    "title": "Psychology of Mindfulness",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC140",
+    "title": "The Social Brain",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC141",
+    "title": "Human Neuroscience",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -32263,7 +41617,25 @@
   },
   {
     "code": "PSYC143",
+    "title": "Advanced Statistics I",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC143",
+    "title": "Lab, Neuropsychology",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC143",
     "title": "Neuropsychology w/ Lab",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC143",
+    "title": "Soc Cog Affective Neurosc w/lab",
     "campus": "po",
     "credits": 3.0
   },
@@ -32277,6 +41649,18 @@
     "code": "PSYC144S",
     "title": "Culture & Psychobiology of Pain",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC144",
+    "title": "Structural Equation Modeling",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC145",
+    "title": "Mixed Methods Research",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -32305,14 +41689,38 @@
   },
   {
     "code": "PSYC150",
+    "title": "Child Psychopathology",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC150",
     "title": "Psych of Close Relationships",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC150",
+    "title": "Psych of the Black Experience",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC151",
+    "title": "Child Psychopathology",
+    "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "PSYC151",
     "title": "Emotional & Social Intelligence",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC151",
+    "title": "Experimental Child Psychology",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -32328,15 +41736,51 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC152",
+    "title": "Infancy: A Developmental Seminar",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC153",
     "title": "Asian American Psychology",
     "campus": "po",
     "credits": 3.0
   },
   {
+    "code": "PSYC153",
+    "title": "Asian-American Psychology",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC153",
+    "title": "Socialization of Gender",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC154",
+    "title": "Cognitive Development",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC154",
     "title": "Sem: Meditation/Mindfulness",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC154",
+    "title": "Social Psychology with Lab",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC155",
+    "title": "Behavioral Epigenetics",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -32347,8 +41791,32 @@
   },
   {
     "code": "PSYC156",
+    "title": "Applied Developmental Psychology",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC156",
     "title": "Industrial/Organizational Psych",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC156",
+    "title": "Native American Psychology",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC157",
+    "title": "Lab, Research Design & Method",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC157",
+    "title": "Psych of the Black Woman",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -32364,9 +41832,33 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC158",
+    "title": "Intro Stats for Psych w/ lab",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC158",
+    "title": "Lab, Intro Statistics for Psych",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC159",
     "title": "Childhood, Law and Society",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC159",
+    "title": "Psychosocial Determinants Health",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC160",
+    "title": "Cognitive Psychology with Lab",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -32382,15 +41874,33 @@
     "credits": 3.0
   },
   {
-    "code": "PSYC162",
-    "title": "Seminar:Remembering & Forgetting",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "PSYC162L",
     "title": "Psychology and Law Lab",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC162",
+    "title": "Lab, Memory & Language",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC162",
+    "title": "Memory & Language w/Lab",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC162",
+    "title": "Psychology and Law",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC162",
+    "title": "Seminar:Remembering & Forgetting",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -32400,9 +41910,27 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC163",
+    "title": "Psy in Media: Evaluating Claims",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC163",
+    "title": "Social Psych & the Legal System",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC164",
     "title": "Autobiographical Memory",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC164",
+    "title": "Forensic Psychology",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -32412,14 +41940,20 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC165",
+    "title": "Trauma and Memory",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC166",
     "title": "Legitimacy of the Legal System",
     "campus": "pz",
     "credits": 3.0
   },
   {
-    "code": "PSYC167",
-    "title": "Social Cognition and Aging",
+    "code": "PSYC166",
+    "title": "Psyc, Sustain & Environ Decision",
     "campus": "sc",
     "credits": 3.0
   },
@@ -32436,8 +41970,8 @@
     "credits": 3.0
   },
   {
-    "code": "PSYC168",
-    "title": "Social Psychology",
+    "code": "PSYC167",
+    "title": "Social Cognition and Aging",
     "campus": "sc",
     "credits": 3.0
   },
@@ -32448,9 +41982,9 @@
     "credits": 3.0
   },
   {
-    "code": "PSYC169",
-    "title": "The Default Network of the Brain",
-    "campus": "pz",
+    "code": "PSYC168",
+    "title": "Social Psychology",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -32460,9 +41994,45 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC169",
+    "title": "The Default Network of the Brain",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC169",
+    "title": "Topics: Stereotyping & Prejudice",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC170",
+    "title": "Close Relationships-Lifespan",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC170",
+    "title": "Cross-Cultural Psychology",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC170",
     "title": "Emotion",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC170",
+    "title": "Psyc of College Binge Drinking",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC171A",
+    "title": "Research Practicum in Psychology",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -32472,9 +42042,9 @@
     "credits": 3.0
   },
   {
-    "code": "PSYC171A",
-    "title": "Research Practicum in Psychology",
-    "campus": "pz",
+    "code": "PSYC172",
+    "title": "Environmental Psychology",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -32490,9 +42060,27 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC173",
+    "title": "Organizational Psychology",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC174",
     "title": "Ethnic Minority Mental Health",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC174",
+    "title": "Is Freud Really Dead?",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC175",
+    "title": "Seminar on Diverse Teams at Work",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -32502,15 +42090,15 @@
     "credits": 3.0
   },
   {
-    "code": "PSYC176",
-    "title": "Psychology of Health & Medicine",
-    "campus": "po",
+    "code": "PSYC175",
+    "title": "Survey of Clinical Psychology",
+    "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "PSYC177",
-    "title": "Organiz Communication/Leadership",
-    "campus": "cmc",
+    "code": "PSYC176",
+    "title": "Psychology of Health & Medicine",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -32532,20 +42120,26 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC177",
+    "title": "Organiz Communication/Leadership",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC178",
     "title": "Drugs and Behavior",
     "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "PSYC179",
-    "title": "Special Topics in Psychology",
+    "code": "PSYC179A",
+    "title": "Personality Psychology",
     "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "PSYC179A",
-    "title": "Personality Psychology",
+    "title": "Spec Top: Personality Psychology",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -32574,15 +42168,21 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC179F1HM",
+    "title": "Intellectual Virtues",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC179F",
     "title": "Intellectual Virtues",
     "campus": "hmc",
     "credits": 3.0
   },
   {
-    "code": "PSYC179F1HM",
-    "title": "Intellectual Virtues",
-    "campus": "hmc",
+    "code": "PSYC179",
+    "title": "Forensic Psychology",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -32610,9 +42210,9 @@
     "credits": 3.0
   },
   {
-    "code": "PSYC180",
-    "title": "Forensic Psychology",
-    "campus": "cmc",
+    "code": "PSYC179",
+    "title": "Special Topics in Psychology",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -32629,6 +42229,18 @@
   },
   {
     "code": "PSYC180C",
+    "title": "Climate Sci and Human Behavior",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC180C",
+    "title": "Psychology of Climate Change",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC180C",
     "title": "Seminar in Cultural Neuroscience",
     "campus": "po",
     "credits": 3.0
@@ -32640,8 +42252,20 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC180",
+    "title": "Forensic Psychology",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC180G",
     "title": "Attachment Theory",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC180G",
+    "title": "Personality Disorders",
     "campus": "po",
     "credits": 3.0
   },
@@ -32664,8 +42288,20 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC180L",
+    "title": "Study of Lives Lab",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC180M",
     "title": "Chicano/Latino Cultural Psych",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC180M",
+    "title": "Seminar in Cultural Psychology",
     "campus": "po",
     "credits": 3.0
   },
@@ -32682,9 +42318,27 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC180P",
+    "title": "Study of Lives Practicum",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC180S",
+    "title": "Psych of Addictive Behaviors",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC180S",
     "title": "Substance Use Disorders",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC180",
+    "title": "Study of Lives",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -32712,15 +42366,63 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC181",
+    "title": "Psychological Disorders",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC181",
+    "title": "Topics in Clinical Psychology",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC182",
     "title": "Black Psychologists: Women",
     "campus": "pz",
     "credits": 3.0
   },
   {
+    "code": "PSYC182",
+    "title": "Machine Learning w Neural Signal",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC182",
+    "title": "Network Sci & Machine Learning",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC182",
+    "title": "Seminar in Psychology of Art",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC183",
+    "title": "Data Science Ethics & Justice",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC183",
     "title": "Ethnic Psychology Laboratory",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC183",
+    "title": "Human Data Science Ethics",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC184",
+    "title": "Computational Psychiatry",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -32736,14 +42438,44 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC184",
+    "title": "Psychology of Food and Eating",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC185B",
+    "title": "Political Psychology",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC185",
     "title": "Health Psychology",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "PSYC185B",
+    "code": "PSYC185",
+    "title": "IGLAS Seminar",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC185",
     "title": "Political Psychology",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC185",
+    "title": "Psych: History, Science, Applic",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC186",
+    "title": "Internships in Psychology",
     "campus": "pz",
     "credits": 3.0
   },
@@ -32755,8 +42487,32 @@
   },
   {
     "code": "PSYC187",
+    "title": "Dialectical Behavior Therapy",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC187",
+    "title": "Internships in Psychology",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC187",
     "title": "Practicum in Org Intervention",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC188",
+    "title": "Psychology and Law",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC188",
+    "title": "Seminar Body Weight Reg & Obes",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -32766,9 +42522,9 @@
     "credits": 3.0
   },
   {
-    "code": "PSYC189",
-    "title": "Sem in Clinical Psyc w Practicum",
-    "campus": "cmc",
+    "code": "PSYC188",
+    "title": "Seminar: African American Psyc",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -32781,6 +42537,12 @@
     "code": "PSYC189B",
     "title": "Educational Psychology",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC189",
+    "title": "Ethical Issues in Psychology",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -32838,6 +42600,12 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC189",
+    "title": "Sem in Clinical Psyc w Practicum",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC189X",
     "title": "Advanced Statistics",
     "campus": "po",
@@ -32850,15 +42618,15 @@
     "credits": 3.0
   },
   {
-    "code": "PSYC190",
-    "title": "Advanced Psychology & Law",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "PSYC190A",
     "title": "Senior Seminar in Psychology",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC190",
+    "title": "Advanced Psychology & Law",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -32868,14 +42636,20 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC190",
+    "title": "History and Systems in Psych",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC190R",
     "title": "Senior Research in Psychology",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "PSYC191",
-    "title": "Senior Thesis",
+    "code": "PSYC190",
+    "title": "Senior Seminar in Psychology",
     "campus": "po",
     "credits": 3.0
   },
@@ -32892,8 +42666,14 @@
     "credits": 3.0
   },
   {
-    "code": "PSYC192",
-    "title": "Seminar in Psychology of Aging",
+    "code": "PSYC191",
+    "title": "Senior Thesis",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC191",
+    "title": "Senior Thesis in Psychology",
     "campus": "pz",
     "credits": 3.0
   },
@@ -32916,15 +42696,39 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC192",
+    "title": "Seminar in Psychology of Aging",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC193",
+    "title": "Global Mental Health Seminar",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC193",
     "title": "Health Disparities Seminar",
     "campus": "pz",
     "credits": 3.0
   },
   {
+    "code": "PSYC193",
+    "title": "Senior Thesis: Spring",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC194",
     "title": "Seminar in Social Psychology",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC195",
+    "title": "Internship in Psychology",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -32937,12 +42741,6 @@
     "code": "PSYC196",
     "title": "Stress Depresssion & Psychobiol",
     "campus": "pz",
-    "credits": 3.0
-  },
-  {
-    "code": "PSYC197",
-    "title": "Directed Reading/Research",
-    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -32964,15 +42762,39 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC197",
+    "title": "Directed Reading/Research",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC197",
+    "title": "Seminar in Clinical Psychology",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC198",
+    "title": "Independent Internship",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC198",
     "title": "Psych Senior Research Seminar",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "PSYC199",
-    "title": "Ind Std: Psychology",
-    "campus": "cgu",
+    "code": "PSYC198",
+    "title": "Seminar in Personality",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC198",
+    "title": "Summer Reading & Research",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -32994,9 +42816,27 @@
     "credits": 3.0
   },
   {
+    "code": "PSYC199",
+    "title": "Ind Std: Psychology",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC199",
+    "title": "Independent Study in Psychology",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "PSYC199RAPO",
     "title": "Psychology: Research Asstship",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PSYC199",
+    "title": "Seminar in Developmental Psych",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -33258,12 +43098,6 @@
     "credits": 3.0
   },
   {
-    "code": "REL",
-    "title": "Hindu Sacred Scriptures",
-    "campus": "cgu",
-    "credits": 3.0
-  },
-  {
     "code": "REL302",
     "title": "Introductory Hebrew",
     "campus": "cgu",
@@ -33330,14 +43164,14 @@
     "credits": 3.0
   },
   {
-    "code": "REL401",
-    "title": "Arabic",
+    "code": "REL401A",
+    "title": "Arabic I",
     "campus": "cgu",
     "credits": 3.0
   },
   {
-    "code": "REL401A",
-    "title": "Arabic I",
+    "code": "REL401",
+    "title": "Arabic",
     "campus": "cgu",
     "credits": 3.0
   },
@@ -33428,6 +43262,114 @@
   {
     "code": "REL485",
     "title": "New Testament & Greco-Roman Rel",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "REL",
+    "title": "Akkadian",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "REL",
+    "title": "Basic Aspects of the Study of",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "REL",
+    "title": "Bhagadvagita",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "REL",
+    "title": "Coptic Old Testament",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "REL",
+    "title": "Foundations Hindu Art/Architect",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "REL",
+    "title": "Gender, Power & Nationalism",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "REL",
+    "title": "God in Recent Philosoph Theology",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "REL",
+    "title": "Hindu Sacred Scriptures",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "REL",
+    "title": "History Biblical Interpretation",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "REL",
+    "title": "Intro to Process Theology",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "REL",
+    "title": "Islam in the American Mosaic",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "REL",
+    "title": "Paul & the Pauline School",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "REL",
+    "title": "Prophecy & Prophetic Literature",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "REL",
+    "title": "Race/Ethnicity American Religion",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "REL",
+    "title": "Study of Hebrew Bible",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "REL",
+    "title": "Survey:Islamic Theol/Phil/Mystic",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "REL",
+    "title": "US Religions, 1870-Present",
+    "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "REL",
+    "title": "Whitehead & Deleuze",
     "campus": "cgu",
     "credits": 3.0
   },
@@ -33571,6 +43513,12 @@
   },
   {
     "code": "RLST059",
+    "title": "Dreams and Afterworlds in Islam",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "RLST059",
     "title": "The Afterworld in Islamic Tradtn",
     "campus": "cmc",
     "credits": 3.0
@@ -33578,6 +43526,12 @@
   {
     "code": "RLST060",
     "title": "Feminist Interpret of the Bible",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "RLST061",
+    "title": "New Testament Christian Origins",
     "campus": "sc",
     "credits": 3.0
   },
@@ -33609,6 +43563,12 @@
     "code": "RLST078",
     "title": "Matriarchal Societies",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "RLST080",
+    "title": "Congregations and Community",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -33649,6 +43609,12 @@
   },
   {
     "code": "RLST088",
+    "title": "China: Gender Cosmology & State",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "RLST088",
     "title": "Prophets, Kings and Politics",
     "campus": "po",
     "credits": 3.0
@@ -33668,6 +43634,12 @@
   {
     "code": "RLST091",
     "title": "Heretics in Early Christianity",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "RLST092",
+    "title": "Intro to Early Christianities",
     "campus": "sc",
     "credits": 3.0
   },
@@ -33708,6 +43680,12 @@
     "credits": 3.0
   },
   {
+    "code": "RLST097",
+    "title": "Queer African Christianities",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "RLST100",
     "title": "Worlds of Buddhism",
     "campus": "po",
@@ -33716,6 +43694,18 @@
   {
     "code": "RLST101A",
     "title": "Sanskrit & Indian Epics I",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "RLST101A",
+    "title": "The Mahabharata",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "RLST101B",
+    "title": "Ramayana: Lit/Politics/Culture",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -33757,6 +43747,12 @@
   },
   {
     "code": "RLST107",
+    "title": "Buddhist Modernity in China",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "RLST107",
     "title": "Making Modern Chinese Buddhism",
     "campus": "po",
     "credits": 3.0
@@ -33794,6 +43790,18 @@
   {
     "code": "RLST113",
     "title": "God, Darwin, Design in America",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "RLST113",
+    "title": "God, Darwin, and Design",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "RLST114",
+    "title": "2038: Prophecy, Apocalypse",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -33847,6 +43855,12 @@
   },
   {
     "code": "RLST122",
+    "title": "Arab Cultural Histories",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "RLST122",
     "title": "Biblical Interpretation",
     "campus": "cmc",
     "credits": 3.0
@@ -33867,6 +43881,12 @@
     "code": "RLST128",
     "title": "Religion of Islam",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "RLST128",
+    "title": "The Religion of Islam",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -33891,6 +43911,12 @@
     "code": "RLST132",
     "title": "Messiahs & the Millennium",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "RLST132",
+    "title": "Messiahs and the Millennium",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -34056,12 +44082,6 @@
     "credits": 3.0
   },
   {
-    "code": "RLST161",
-    "title": "Gurus, Swamis, & Others",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "RLST161A",
     "title": "Contemp Relig Leaders in India",
     "campus": "cmc",
@@ -34070,6 +44090,12 @@
   {
     "code": "RLST161B",
     "title": "Contemp Relig Leaders in India",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "RLST161",
+    "title": "Gurus, Swamis, & Others",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -34093,13 +44119,13 @@
   },
   {
     "code": "RLST165",
-    "title": "Religion & Politics: Europe",
+    "title": "Rel. & Politics: Medieval Europe",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "RLST166",
-    "title": "Comparative Studies in Religion",
+    "code": "RLST165",
+    "title": "Religion & Politics: Europe",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -34113,6 +44139,18 @@
     "code": "RLST166B",
     "title": "Relig, Politcs & Global Violence",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "RLST166",
+    "title": "Comparative Studies in Religion",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "RLST167",
+    "title": "Early Christian-Muslim Relations",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -34170,15 +44208,21 @@
     "credits": 3.0
   },
   {
-    "code": "RLST176",
-    "title": "Visionaries/Prophets/Leadership",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "RLST176A",
     "title": "Topics:Feminist NT Contemp Cntxt",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "RLST176",
+    "title": "Topics:Feminist NT Contemp Cntxt",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "RLST176",
+    "title": "Visionaries/Prophets/Leadership",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -34191,12 +44235,6 @@
     "code": "RLST178",
     "title": "The Modern Jewish Experience",
     "campus": "po",
-    "credits": 3.0
-  },
-  {
-    "code": "RLST179",
-    "title": "Special Topics:Religious Studies",
-    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -34236,6 +44274,12 @@
     "credits": 3.0
   },
   {
+    "code": "RLST179",
+    "title": "Special Topics:Religious Studies",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "RLST180",
     "title": "Interpreting Religious Worlds",
     "campus": "hmc",
@@ -34244,6 +44288,12 @@
   {
     "code": "RLST181",
     "title": "Prison Punishment Redemption",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "RLST181",
+    "title": "Prison Punishment Redemption(CP)",
     "campus": "po",
     "credits": 3.0
   },
@@ -34261,14 +44311,32 @@
   },
   {
     "code": "RLST184",
+    "title": "Queer Theory & the Bible",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "RLST184",
     "title": "Science and Religion",
     "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "RLST186",
+    "title": "Poetry and the Bible",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "RLST186",
     "title": "Research Practicum in Archeology",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "RLST187",
+    "title": "Intrpret Jesus:Global/Gendr Prsp",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -34362,21 +44430,27 @@
     "credits": 3.0
   },
   {
-    "code": "RLST190",
-    "title": "Senior Seminar",
-    "campus": "po",
-    "credits": 3.0
-  },
-  {
     "code": "RLST190SCJT",
     "title": "Sr Seminar: Religious Studies",
     "campus": "sc",
     "credits": 3.0
   },
   {
+    "code": "RLST190",
+    "title": "Senior Seminar",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "RLST191",
     "title": "Senior Thesis",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "RLST191",
+    "title": "Senior Thesis: Religious Studies",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -34387,14 +44461,14 @@
   },
   {
     "code": "RLST198",
-    "title": "Summer Reading & Research",
-    "campus": "po",
+    "title": "Independ Intern: Religious St",
+    "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "RLST199",
-    "title": "Independent Study",
-    "campus": "cmc",
+    "code": "RLST198",
+    "title": "Summer Reading & Research",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -34410,6 +44484,18 @@
     "credits": 3.0
   },
   {
+    "code": "RLST199",
+    "title": "Independ St: Religious Studies",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "RLST199",
+    "title": "Independent Study",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "RLST999",
     "title": "Independent Study",
     "campus": "pz",
@@ -34422,8 +44508,20 @@
     "credits": 3.0
   },
   {
+    "code": "RUSS001",
+    "title": "Elementary Russian 1",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "RUSS002",
     "title": "Elementary Russian",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "RUSS002",
+    "title": "Elementary Russian 2",
     "campus": "po",
     "credits": 3.0
   },
@@ -34471,6 +44569,12 @@
   },
   {
     "code": "RUSS183",
+    "title": "Comedy in Russ Lit and Film",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "RUSS183",
     "title": "Russian Comedy in Film & Fiction",
     "campus": "po",
     "credits": 3.0
@@ -34478,6 +44582,12 @@
   {
     "code": "RUSS184",
     "title": "Russian Cinema Stalin to Present",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "RUSS184",
+    "title": "The Art of Translation",
     "campus": "po",
     "credits": 3.0
   },
@@ -34590,8 +44700,20 @@
     "credits": 3.0
   },
   {
+    "code": "RUST105",
+    "title": "Stranger Than Fiction",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "RUST110",
     "title": "Modernism in Russia & Europe",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "RUST110",
+    "title": "Russian and East European Cinema",
     "campus": "po",
     "credits": 3.0
   },
@@ -34628,6 +44750,12 @@
   {
     "code": "RUST175",
     "title": "Russia: Empire & Ethnicity",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "RUST175",
+    "title": "Russia: Empire and Identity",
     "campus": "po",
     "credits": 3.0
   },
@@ -34669,13 +44797,19 @@
   },
   {
     "code": "SC",
+    "title": "Online Course",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "SC",
     "title": "Scripps Foreign Language GE",
     "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "SI",
-    "title": "Speaking Intnsve Req Fulfillment",
+    "code": "SIOPT-IP",
+    "title": "SI OPTIONAL COURSE-IN PROGRESS",
     "campus": "po",
     "credits": 3.0
   },
@@ -34686,26 +44820,26 @@
     "credits": 3.0
   },
   {
-    "code": "SIOPT-IP",
-    "title": "SI OPTIONAL COURSE-IN PROGRESS",
-    "campus": "po",
-    "credits": 3.0
-  },
-  {
     "code": "SIPZ195",
     "title": "Ctr for Scl Inquiry: Democracies",
     "campus": "pz",
     "credits": 3.0
   },
   {
-    "code": "SOC",
-    "title": "Sociology: Directed Readings",
+    "code": "SI",
+    "title": "Speaking Intnsve Req Fulfillment",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "SOC001",
     "title": "Sociology & View of the World",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "SOC003",
+    "title": "Transatlantic Black/Asian Film",
     "campus": "pz",
     "credits": 3.0
   },
@@ -34794,6 +44928,12 @@
     "credits": 3.0
   },
   {
+    "code": "SOC030",
+    "title": "Deviant Sex Cults?",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "SOC031",
     "title": "Exploring Urban Landscapes",
     "campus": "pz",
@@ -34873,7 +45013,25 @@
   },
   {
     "code": "SOC051",
+    "title": "Caste, Class & Colonialism",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "SOC051",
     "title": "Introduction to Sociology",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "SOC055",
+    "title": "Juvenile Delinquency",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "SOC055",
+    "title": "Lab, Population Trends & Issues",
     "campus": "po",
     "credits": 3.0
   },
@@ -34945,6 +45103,18 @@
   },
   {
     "code": "SOC075",
+    "title": "American Settler Colonialism",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "SOC075",
+    "title": "Global Media and Culture",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "SOC075",
     "title": "Social and Political Movements",
     "campus": "po",
     "credits": 3.0
@@ -34986,14 +45156,14 @@
     "credits": 3.0
   },
   {
-    "code": "SOC082",
-    "title": "Racial Politics of Teaching",
+    "code": "SOC082A",
+    "title": "Race Ethnicity&Politics of Teach",
     "campus": "pz",
     "credits": 3.0
   },
   {
-    "code": "SOC082A",
-    "title": "Race Ethnicity&Politics of Teach",
+    "code": "SOC082",
+    "title": "Racial Politics of Teaching",
     "campus": "pz",
     "credits": 3.0
   },
@@ -35064,6 +45234,18 @@
     "credits": 3.0
   },
   {
+    "code": "SOC090",
+    "title": "Globalizations",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "SOC090",
+    "title": "Sociology:Arab-Israeli Coflict",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "SOC091",
     "title": "Political Sociology",
     "campus": "pz",
@@ -35120,6 +45302,12 @@
   {
     "code": "SOC103",
     "title": "MMUF Seminar",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "SOC104",
+    "title": "Desiring The Other",
     "campus": "pz",
     "credits": 3.0
   },
@@ -35184,6 +45372,12 @@
     "credits": 3.0
   },
   {
+    "code": "SOC114",
+    "title": "Sociology of Religion",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "SOC115",
     "title": "Sociology of Law",
     "campus": "pz",
@@ -35196,6 +45390,12 @@
     "credits": 3.0
   },
   {
+    "code": "SOC116",
+    "title": "Women and Law",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "SOC117",
     "title": "Immigrant America",
     "campus": "pz",
@@ -35205,6 +45405,12 @@
     "code": "SOC118",
     "title": "Japanese Families",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "SOC118",
+    "title": "Sociology of Secularity",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -35239,8 +45445,20 @@
   },
   {
     "code": "SOC124",
+    "title": "Geohazards*",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "SOC124",
     "title": "Global Asia America",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "SOC124",
+    "title": "Race, Place and Space",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -35250,9 +45468,21 @@
     "credits": 3.0
   },
   {
+    "code": "SOC125",
+    "title": "Workshop in Urban Studies",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "SOC126",
     "title": "Immigration & Second Generation",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "SOC126",
+    "title": "Race & Family as Organizations",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -35264,6 +45494,12 @@
   {
     "code": "SOC129",
     "title": "Sociology of Aging",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "SOC130",
+    "title": "Selling Emotions",
     "campus": "pz",
     "credits": 3.0
   },
@@ -35310,6 +45546,12 @@
     "credits": 3.0
   },
   {
+    "code": "SOC142",
+    "title": "Sociology of Race & Ethnicity",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "SOC145",
     "title": "Restructuring Communities",
     "campus": "pz",
@@ -35317,7 +45559,19 @@
   },
   {
     "code": "SOC146",
+    "title": "Sociology of Homelessness",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "SOC146",
     "title": "Women's Roles in Society",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "SOC147",
+    "title": "Sociology of Poverty",
     "campus": "po",
     "credits": 3.0
   },
@@ -35337,6 +45591,18 @@
     "code": "SOC149",
     "title": "Self and Society",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "SOC150",
+    "title": "Chicanos/Latinos & Education CP",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "SOC150",
+    "title": "Chicanx/Latinx & Education CP",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -35377,8 +45643,20 @@
   },
   {
     "code": "SOC157",
+    "title": "Gender in American Society",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "SOC157",
     "title": "History & Devel Soc Theory II",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "SOC157",
+    "title": "Men & Women in American Society",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -35424,12 +45702,6 @@
     "credits": 3.0
   },
   {
-    "code": "SOC179",
-    "title": "Introduction to Sociology",
-    "campus": "hmc",
-    "credits": 3.0
-  },
-  {
     "code": "SOC179A",
     "title": "Society, Space, and Environment",
     "campus": "hmc",
@@ -35439,6 +45711,18 @@
     "code": "SOC179B",
     "title": "Society Through Ethnography",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "SOC179",
+    "title": "Introduction to Sociology",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "SOC179",
+    "title": "Social Movements Thru Present",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -35461,13 +45745,13 @@
   },
   {
     "code": "SOC188",
-    "title": "Teaching as Social Change",
+    "title": "Seminar: Sex & Religion",
     "campus": "pz",
     "credits": 3.0
   },
   {
-    "code": "SOC189",
-    "title": "Seminar: Contemporary Secularity",
+    "code": "SOC188",
+    "title": "Teaching as Social Change",
     "campus": "pz",
     "credits": 3.0
   },
@@ -35520,6 +45804,12 @@
     "credits": 3.0
   },
   {
+    "code": "SOC189",
+    "title": "Seminar: Contemporary Secularity",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "SOC189T",
     "title": "Gender, Sexuality, and Culture",
     "campus": "po",
@@ -35550,9 +45840,27 @@
     "credits": 3.0
   },
   {
+    "code": "SOC190",
+    "title": "Soc of Palestine-Israel Conflict",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "SOC191",
     "title": "Senior Thesis",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "SOC191",
+    "title": "Sociology of the West Indies",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "SOC191",
+    "title": "Sr Thesis: Sociology",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -35580,12 +45888,6 @@
     "credits": 3.0
   },
   {
-    "code": "SOC199",
-    "title": "Senior Thesis",
-    "campus": "pz",
-    "credits": 3.0
-  },
-  {
     "code": "SOC199A",
     "title": "Senior Seminar",
     "campus": "pz",
@@ -35598,9 +45900,33 @@
     "credits": 3.0
   },
   {
+    "code": "SOC199",
+    "title": "Senior Thesis",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "SOC999",
     "title": "Independent Study",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "SOC",
+    "title": "Sociology: Directed Readings",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "SOC",
+    "title": "Sociology: Independent Research",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "SOC",
+    "title": "Sociology: Research Asstship",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -35618,12 +45944,6 @@
   {
     "code": "SOSC150",
     "title": "Public Speaking/Sci & Citizenshp",
-    "campus": "hmc",
-    "credits": 3.0
-  },
-  {
-    "code": "SOSC179",
-    "title": "Special Topics in Social Science",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -35646,6 +45966,12 @@
     "credits": 3.0
   },
   {
+    "code": "SOSC179",
+    "title": "Special Topics in Social Science",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "SOSC180",
     "title": "Tropical Forests: Policy & Prac",
     "campus": "hmc",
@@ -35655,6 +45981,12 @@
     "code": "SOSC197",
     "title": "Independent Study in Social Sci",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN001",
+    "title": "Elementary Spanish",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -35670,9 +46002,15 @@
     "credits": 3.0
   },
   {
-    "code": "SPAN011",
-    "title": "Spanish Conversation, Intermed",
+    "code": "SPAN002",
+    "title": "Elementary Spanish",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN002",
+    "title": "Introductory Spanish",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -35685,6 +46023,24 @@
     "code": "SPAN011B",
     "title": "Community-based Spanish Pract II",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN011",
+    "title": "Community-based Span Practicum",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN011",
+    "title": "Conversation:Contemporary Span",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN011",
+    "title": "Spanish Conversation, Intermed",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -35725,8 +46081,20 @@
   },
   {
     "code": "SPAN044",
+    "title": "Adv. Spanish: Language & Culture",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN044",
     "title": "Advanced Spanish",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN044",
+    "title": "Advanced Spanish: Culture & Soc",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -35738,6 +46106,12 @@
   {
     "code": "SPAN045",
     "title": "Public Health in Latin America",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN050",
+    "title": "Adv Spanish for Heritge Speakers",
     "campus": "pz",
     "credits": 3.0
   },
@@ -35791,6 +46165,18 @@
   },
   {
     "code": "SPAN100",
+    "title": "Cultural Competence Hlth Profess",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN100",
+    "title": "Sciences and Cultural Competence",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN100",
     "title": "Spanish in the Community",
     "campus": "pz",
     "credits": 3.0
@@ -35802,15 +46188,33 @@
     "credits": 3.0
   },
   {
-    "code": "SPAN102",
-    "title": "Intro Lat-Am Cultural Studies",
-    "campus": "cmc",
+    "code": "SPAN101",
+    "title": "Introduction Literary Analysis",
+    "campus": "sc",
     "credits": 3.0
   },
   {
     "code": "SPAN102B",
     "title": "Spanish Cultural Studies",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN102",
+    "title": "Intro Lat-Am Cultural Studies",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN102",
+    "title": "Latin American Culture & Civ",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN103",
+    "title": "Adv Conversation and Composition",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -35823,6 +46227,24 @@
     "code": "SPAN104",
     "title": "Humor in Hispanic Literature",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN104",
+    "title": "Negotiating Hispanic Contexts",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN104",
+    "title": "Oral History",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN104",
+    "title": "Public Health in Latin America",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -35887,6 +46309,18 @@
   },
   {
     "code": "SPAN120A",
+    "title": "Medieval & Early Modern Lit",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN120A",
+    "title": "Survey of Spanish Literature",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN120B",
     "title": "Survey of Spanish Literature",
     "campus": "po",
     "credits": 3.0
@@ -35911,8 +46345,26 @@
   },
   {
     "code": "SPAN124",
+    "title": "Language in Spain",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN124",
     "title": "Visions of Democracy",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN125A",
+    "title": "Blood & Guts",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN125A",
+    "title": "Blood & Guts:Decadent Naturalism",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -35922,9 +46374,21 @@
     "credits": 3.0
   },
   {
+    "code": "SPAN125A",
+    "title": "Survey of Spanish American Lit",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "SPAN125B",
     "title": "Intro to Latin-Amer Lit & Civ II",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN125B",
+    "title": "Survey of Spanish American Lit",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -35940,9 +46404,27 @@
     "credits": 3.0
   },
   {
+    "code": "SPAN127",
+    "title": "Spanish Phonetics and Phonology",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "SPAN128",
     "title": "Hispanic/Latino Lit in New York",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN128",
+    "title": "Poverty, Lit & Social Justice",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN129",
+    "title": "Early Modern Women Writers",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -35977,6 +46459,12 @@
   },
   {
     "code": "SPAN135",
+    "title": "Los Angeles: La Ciudad, su Gente",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN135",
     "title": "The Boom:Modern Latin Amer Novel",
     "campus": "po",
     "credits": 3.0
@@ -35988,6 +46476,12 @@
     "credits": 3.0
   },
   {
+    "code": "SPAN137",
+    "title": "Translating the Aztecs",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "SPAN139",
     "title": "Plants, Magic, and Race",
     "campus": "sc",
@@ -35995,8 +46489,26 @@
   },
   {
     "code": "SPAN140",
+    "title": "From Borges to Literatura Lite\"\"",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN140",
+    "title": "Gender/Genre Lat Am Lit/Culture",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN140",
     "title": "National Identity Discourses",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN140",
+    "title": "Spanish Transition Almodovar",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -36019,6 +46531,12 @@
   },
   {
     "code": "SPAN146",
+    "title": "El deseo de la palabra",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN146",
     "title": "Latin Amer/Latin@ Poetry",
     "campus": "po",
     "credits": 3.0
@@ -36036,8 +46554,20 @@
     "credits": 3.0
   },
   {
+    "code": "SPAN150",
+    "title": "In Quest of God in Latin America",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "SPAN151",
     "title": "Necropolis: Detective Novels",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN152",
+    "title": "Border Thinking in Spain",
     "campus": "sc",
     "credits": 3.0
   },
@@ -36048,9 +46578,27 @@
     "credits": 3.0
   },
   {
+    "code": "SPAN152",
+    "title": "Indios: Latin Amer Indigenous",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN152",
+    "title": "Multicultural Ethnic Europe",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "SPAN153",
     "title": "Pol/Soc Leadership in Latin Amer",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN153",
+    "title": "Spanglish in Context",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -36060,9 +46608,27 @@
     "credits": 3.0
   },
   {
+    "code": "SPAN154",
+    "title": "Trans-Caribbean Formations",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN154",
+    "title": "Women in Spain: Making History",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "SPAN155",
     "title": "Latin American Short Story",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN155",
+    "title": "Short Fiction by Spanish Women",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -36072,9 +46638,27 @@
     "credits": 3.0
   },
   {
+    "code": "SPAN156",
+    "title": "Revisit Latin Amer Short Story",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN157",
+    "title": "19C Latin American Literature",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "SPAN157",
     "title": "Hist Memory & Nostalgia Span-Amr",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN158",
+    "title": "Banana Republics",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -36090,15 +46674,45 @@
     "credits": 3.0
   },
   {
+    "code": "SPAN159",
+    "title": "Multilingual Spain",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN160",
+    "title": "Jews, Moors, Indians:Span Empire",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN160",
+    "title": "Migracion: Lo Local Y Lo Global",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "SPAN160",
     "title": "Nation & Novel: 20th C. Spain",
     "campus": "cmc",
     "credits": 3.0
   },
   {
+    "code": "SPAN160",
+    "title": "Spain at a Crossroads",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "SPAN161",
     "title": "Spanish Civil War & the Novel",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN162",
+    "title": "Journalism in Latin America",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -36111,6 +46725,12 @@
     "code": "SPAN163",
     "title": "Afrolatinidades",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN163",
+    "title": "Pais Vasco or Euskal Herria",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -36144,6 +46764,18 @@
     "credits": 3.0
   },
   {
+    "code": "SPAN174",
+    "title": "Lost in Translation",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN175",
+    "title": "Aftermath of Spanish Civil War",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "SPAN175",
     "title": "Romantics & Realists:19thC Lit",
     "campus": "po",
@@ -36163,8 +46795,20 @@
   },
   {
     "code": "SPAN178",
+    "title": "Spanish Civil War Representatns",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN178",
     "title": "The New Latin American Cinema",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN179",
+    "title": "LA: The City",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -36174,9 +46818,21 @@
     "credits": 3.0
   },
   {
+    "code": "SPAN179",
+    "title": "Women Writers of Hispanic World",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "SPAN180",
     "title": "Spanish Literature 1898-1920",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN180",
+    "title": "Spanish Literature 1898-1936",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -36192,6 +46848,24 @@
     "credits": 3.0
   },
   {
+    "code": "SPAN182",
+    "title": "Poetics, Identity, Difference",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN182",
+    "title": "Reading the Hispanic Caribbean",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN183",
+    "title": "Intercul & Bilingualism in Andes",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "SPAN183",
     "title": "Pre-Hispanic Oral Trad - Mexico",
     "campus": "pz",
@@ -36201,6 +46875,12 @@
     "code": "SPAN184",
     "title": "Lit of the Zapatista Rebellion",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN184",
+    "title": "The Image and the Word",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -36229,6 +46909,12 @@
   },
   {
     "code": "SPAN189",
+    "title": "Contemp Issues Span-Speak World",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN189",
     "title": "Spanish Across the Curriculum",
     "campus": "cmc",
     "credits": 3.0
@@ -36246,6 +46932,12 @@
     "credits": 3.0
   },
   {
+    "code": "SPAN191",
+    "title": "Senior Thesis in Spanish",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "SPAN192",
     "title": "Senior Paper",
     "campus": "po",
@@ -36259,14 +46951,14 @@
   },
   {
     "code": "SPAN198",
-    "title": "Summer Reading & Research",
-    "campus": "po",
+    "title": "Independent Internship",
+    "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "SPAN199",
-    "title": "Independent Study in Spanish",
-    "campus": "cmc",
+    "code": "SPAN198",
+    "title": "Summer Reading & Research",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -36279,6 +46971,18 @@
     "code": "SPAN199IRPO",
     "title": "Spanish: Independent Research",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN199",
+    "title": "Independent Study in Spanish",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN199",
+    "title": "Senior Research Project Seminar",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -36444,8 +47148,14 @@
     "credits": 3.0
   },
   {
-    "code": "STS",
-    "title": "Sci Tech Soc: Directed Readings",
+    "code": "STS001",
+    "title": "Intro to Sci, Tech and Society",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "STS001",
+    "title": "Intro to Sci, Tech, & Society",
     "campus": "po",
     "credits": 3.0
   },
@@ -36480,9 +47190,21 @@
     "credits": 3.0
   },
   {
+    "code": "STS081",
+    "title": "Sci & Tech in the Early Modern",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "STS082",
     "title": "History of Science & Technology",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "STS082",
+    "title": "Modern Science",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -36498,20 +47220,14 @@
     "credits": 3.0
   },
   {
-    "code": "STS114",
-    "title": "Social/Politic Issues in Clinic",
-    "campus": "hmc",
-    "credits": 3.0
-  },
-  {
     "code": "STS114S",
     "title": "Social/Poli Issues in Clinic",
     "campus": "hmc",
     "credits": 3.0
   },
   {
-    "code": "STS179",
-    "title": "Spec Topics: Sci, Tech, Society",
+    "code": "STS114",
+    "title": "Social/Politic Issues in Clinic",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -36576,6 +47292,12 @@
     "credits": 3.0
   },
   {
+    "code": "STS179",
+    "title": "Spec Topics: Sci, Tech, Society",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "STS185",
     "title": "Sci/Engr from Other Perspective",
     "campus": "hmc",
@@ -36589,8 +47311,20 @@
   },
   {
     "code": "STS190",
+    "title": "Senior Integrative Seminar",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "STS190",
     "title": "Senior Seminar: Sci,Tech,Society",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "STS190",
+    "title": "Senior Thesis",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -36600,9 +47334,21 @@
     "credits": 3.0
   },
   {
+    "code": "STS191",
+    "title": "Sr Thesis:Sci,Technology+Society",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "STS197",
     "title": "Directed Reading / Research",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "STS198",
+    "title": "Independ Intern:Sci,Tech+Society",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -36621,6 +47367,18 @@
     "code": "STS999",
     "title": "Independent Study",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "STS",
+    "title": "Sci Tech Soc: Directed Readings",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "STS",
+    "title": "Sci Tech Soc: Indep Research",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -36649,8 +47407,50 @@
   },
   {
     "code": "TEST001",
+    "title": "Test Course",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "TEST001",
+    "title": "Test Course at Scripps",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "TEST001",
+    "title": "Test Course for Web Reg",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "TEST001",
+    "title": "Test Course for Web Registration",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "TEST001",
     "title": "Test Course for Web-Reg Testing",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "TEST001",
+    "title": "Test lab course for con-rec test",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "TEST001",
+    "title": "Your Course 101",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "TEST002",
+    "title": "Test Course at Scripps",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -36660,15 +47460,63 @@
     "credits": 3.0
   },
   {
+    "code": "TEST002",
+    "title": "Test Course--Disregard",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "TEST002",
+    "title": "Your Course 102",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "TEST003",
+    "title": "Test Course at Scripps",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "TEST003",
+    "title": "Test Course for Web Reg",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "TEST003",
     "title": "Test Course for web-reg - PERM",
     "campus": "hmc",
     "credits": 3.0
   },
   {
+    "code": "TEST003",
+    "title": "This is a test (3)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "TEST004",
     "title": "Pre-req testing course",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "TEST004",
+    "title": "Test Course - PERM REQ",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "TEST004",
+    "title": "Test Course at Scripps",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "TEST004",
+    "title": "Test course- disregard",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -36681,6 +47529,18 @@
     "code": "TEST006",
     "title": "Test Course 6",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "TEST006",
+    "title": "Test Course at Scripps",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "TEST007",
+    "title": "Test Course at Scripps",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -36804,6 +47664,18 @@
     "credits": 3.0
   },
   {
+    "code": "THEA012",
+    "title": "Interm. Acting: Scene and Voice",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "THEA012",
+    "title": "Intermediate Acting Lab",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "THEA013",
     "title": "Corporeal Mime",
     "campus": "po",
@@ -36829,6 +47701,12 @@
   },
   {
     "code": "THEA022",
+    "title": "Lighting & Projection Technology",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "THEA022",
     "title": "Stage Lighting Technology",
     "campus": "po",
     "credits": 3.0
@@ -36842,6 +47720,12 @@
   {
     "code": "THEA024",
     "title": "Sound for the Theatre",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "THEA024",
+    "title": "Theatrical Sound Technology",
     "campus": "po",
     "credits": 3.0
   },
@@ -36942,14 +47826,14 @@
     "credits": 3.0
   },
   {
-    "code": "THEA055",
-    "title": "Stage Mgmt: Practicum & Pedagogy",
+    "code": "THEA055H",
+    "title": "Stage Management: Practicum",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "THEA055H",
-    "title": "Stage Management: Practicum",
+    "code": "THEA055",
+    "title": "Stage Mgmt: Practicum & Pedagogy",
     "campus": "po",
     "credits": 3.0
   },
@@ -36960,14 +47844,38 @@
     "credits": 3.0
   },
   {
+    "code": "THEA060",
+    "title": "Theatre for Young Audiences (CP)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "THEA061",
     "title": "Theatre for Young Audiences",
     "campus": "po",
     "credits": 3.0
   },
   {
+    "code": "THEA061",
+    "title": "Theatre for Young Audiences (CP)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "THEA080",
+    "title": "Lab:Scene Design Stage & Screen",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "THEA080",
     "title": "Scene Design for Stage & Screen",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "THEA081",
+    "title": "Costume Design Lab",
     "campus": "po",
     "credits": 3.0
   },
@@ -36980,6 +47888,18 @@
   {
     "code": "THEA082",
     "title": "Lighting Design Stage and Screen",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "THEA082",
+    "title": "The Magic of Theatrical Light",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "THEA083",
+    "title": "Sound Design",
     "campus": "po",
     "credits": 3.0
   },
@@ -37134,6 +48054,18 @@
     "credits": 3.0
   },
   {
+    "code": "THEA130",
+    "title": "Introduction to Directing (CP)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "THEA130",
+    "title": "Lab, Introduction to Directing",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "THEA131",
     "title": "Directors/Actors Studio",
     "campus": "po",
@@ -37170,12 +48102,6 @@
     "credits": 3.0
   },
   {
-    "code": "THEA191",
-    "title": "Senior Thesis in Theatre",
-    "campus": "sc",
-    "credits": 3.0
-  },
-  {
     "code": "THEA191F",
     "title": "Senior Thesis",
     "campus": "po",
@@ -37185,6 +48111,12 @@
     "code": "THEA191H",
     "title": "Senior Thesis",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "THEA191",
+    "title": "Senior Thesis in Theatre",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -37404,12 +48336,6 @@
     "credits": 3.0
   },
   {
-    "code": "WI",
-    "title": "Wrtng Intnsve Req Fulfilled",
-    "campus": "po",
-    "credits": 3.0
-  },
-  {
     "code": "WI-SI",
     "title": "Speaking/Writing Int Req Fulfill",
     "campus": "po",
@@ -37434,14 +48360,26 @@
     "credits": 3.0
   },
   {
+    "code": "WIOPT-IP",
+    "title": "WI OPTIONAL COURSE-IN PROGRESS",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "WIOPT",
     "title": "Writing Intnsv 0ptional Course",
     "campus": "po",
     "credits": 3.0
   },
   {
-    "code": "WIOPT-IP",
-    "title": "WI OPTIONAL COURSE-IN PROGRESS",
+    "code": "WI",
+    "title": "Wrtng Intnsve Req Fulfilled",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "WI",
+    "title": "Wrtng Intnsve Req Fulfillment",
     "campus": "po",
     "credits": 3.0
   },
@@ -37458,14 +48396,14 @@
     "credits": 3.0
   },
   {
-    "code": "WRIT001",
-    "title": "Introduction to Academic Writing",
+    "code": "WRIT001E",
+    "title": "Academic Writing: Extended",
     "campus": "hmc",
     "credits": 3.0
   },
   {
-    "code": "WRIT001E",
-    "title": "Academic Writing: Extended",
+    "code": "WRIT001",
+    "title": "Introduction to Academic Writing",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -37482,14 +48420,14 @@
     "credits": 3.0
   },
   {
-    "code": "WRIT010",
-    "title": "Education, Literacies & Culture",
+    "code": "WRIT010A",
+    "title": "Writing for Int'l Students",
     "campus": "pz",
     "credits": 3.0
   },
   {
-    "code": "WRIT010A",
-    "title": "Writing for Int'l Students",
+    "code": "WRIT010",
+    "title": "Education, Literacies & Culture",
     "campus": "pz",
     "credits": 3.0
   },
@@ -37506,12 +48444,6 @@
     "credits": 3.0
   },
   {
-    "code": "WRIT020",
-    "title": "Writing Seminar: Representing LA",
-    "campus": "pz",
-    "credits": 3.0
-  },
-  {
     "code": "WRIT020A",
     "title": "Creative Nonfiction",
     "campus": "pz",
@@ -37520,6 +48452,12 @@
   {
     "code": "WRIT020B",
     "title": "Creative Nonfiction B",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "WRIT020",
+    "title": "Writing Seminar: Representing LA",
     "campus": "pz",
     "credits": 3.0
   },
@@ -37578,15 +48516,15 @@
     "credits": 3.0
   },
   {
-    "code": "WRIT100",
-    "title": "Teaching & Tutoring Writing",
+    "code": "WRIT100A",
+    "title": "Writing Center Theory & Praxis",
     "campus": "pz",
     "credits": 3.0
   },
   {
-    "code": "WRIT100A",
-    "title": "Writing Center Theory & Praxis",
-    "campus": "pz",
+    "code": "WRIT100",
+    "title": "Advanced Argumentative Writing",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -37599,6 +48537,18 @@
     "code": "WRIT100C",
     "title": "Research About Writing",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "WRIT100",
+    "title": "Teaching & Tutoring Writing",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "WRIT100",
+    "title": "Topics in Advanced Writing",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -37657,6 +48607,12 @@
   },
   {
     "code": "WRIT137",
+    "title": "The Newpaper Op-ed",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "WRIT137",
     "title": "The Newspaper Op-Ed",
     "campus": "sc",
     "credits": 3.0
@@ -37665,6 +48621,12 @@
     "code": "WRIT140",
     "title": "Art & Craft of the Short Story",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "WRIT140",
+    "title": "Creative Nonfiction",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -37686,13 +48648,19 @@
     "credits": 3.0
   },
   {
+    "code": "WRIT175IOSC",
+    "title": "Social Action Writing & Rhetoric",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "WRIT175",
     "title": "Protest Writing and Rhetoric",
     "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "WRIT175IOSC",
+    "code": "WRIT175",
     "title": "Social Action Writing & Rhetoric",
     "campus": "sc",
     "credits": 3.0
@@ -37710,14 +48678,14 @@
     "credits": 3.0
   },
   {
-    "code": "WRIT197",
-    "title": "Special Topics in Writing",
+    "code": "WRIT197G",
+    "title": "Topics Writ: Fiction & Reading",
     "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "WRIT197G",
-    "title": "Topics Writ: Fiction & Reading",
+    "code": "WRIT197H",
+    "title": "Spec Topics: Investigative Fict",
     "campus": "sc",
     "credits": 3.0
   },
@@ -37764,6 +48732,12 @@
     "credits": 3.0
   },
   {
+    "code": "WRIT197",
+    "title": "Special Topics in Writing",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
     "code": "WRIT197T",
     "title": "Topics in Writing: Long Fiction",
     "campus": "sc",
@@ -37783,8 +48757,20 @@
   },
   {
     "code": "WRIT199",
+    "title": "Independent Study in Writing",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "WRIT199",
     "title": "Independent Study: Writing",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "WRIT199",
+    "title": "Senior Thesis",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -37824,12 +48810,6 @@
     "credits": 3.0
   },
   {
-    "code": "XANT190",
-    "title": "Senior Thesis in Anthropology",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "XANT190A",
     "title": "Senior Thesis in Anthropology",
     "campus": "cmc",
@@ -37837,6 +48817,12 @@
   },
   {
     "code": "XANT190B",
+    "title": "Senior Thesis in Anthropology",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "XANT190",
     "title": "Senior Thesis in Anthropology",
     "campus": "cmc",
     "credits": 3.0
@@ -37860,12 +48846,6 @@
     "credits": 3.0
   },
   {
-    "code": "XAST190",
-    "title": "Senior Thesis in Asian Studies",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "XAST190A",
     "title": "Senior Thesis in Asian Studies",
     "campus": "cmc",
@@ -37873,6 +48853,12 @@
   },
   {
     "code": "XAST190B",
+    "title": "Senior Thesis in Asian Studies",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "XAST190",
     "title": "Senior Thesis in Asian Studies",
     "campus": "cmc",
     "credits": 3.0
@@ -37926,6 +48912,12 @@
     "credits": 3.0
   },
   {
+    "code": "XCLA191",
+    "title": "Sr Research in Classical Studies",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "XCLA192",
     "title": "Sr Thesis in Classical Studies",
     "campus": "cmc",
@@ -37938,12 +48930,6 @@
     "credits": 3.0
   },
   {
-    "code": "XCSC190",
-    "title": "Sr Thesis in Computer Science",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "XCSC190A",
     "title": "Sr Thesis in Computer Science",
     "campus": "cmc",
@@ -37951,6 +48937,12 @@
   },
   {
     "code": "XCSC190B",
+    "title": "Sr Thesis in Computer Science",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "XCSC190",
     "title": "Sr Thesis in Computer Science",
     "campus": "cmc",
     "credits": 3.0
@@ -37986,12 +48978,6 @@
     "credits": 3.0
   },
   {
-    "code": "XECA190",
-    "title": "Senior Thesis in Econ-Accounting",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "XECA190A",
     "title": "Senior Thesis in Econ-Accounting",
     "campus": "cmc",
@@ -37999,6 +48985,12 @@
   },
   {
     "code": "XECA190B",
+    "title": "Senior Thesis in Econ-Accounting",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "XECA190",
     "title": "Senior Thesis in Econ-Accounting",
     "campus": "cmc",
     "credits": 3.0
@@ -38016,12 +49008,6 @@
     "credits": 3.0
   },
   {
-    "code": "XECO190",
-    "title": "Senior Thesis in Economics",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "XECO190A",
     "title": "Senior Thesis in Economics",
     "campus": "cmc",
@@ -38029,6 +49015,12 @@
   },
   {
     "code": "XECO190B",
+    "title": "Senior Thesis in Economics",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "XECO190",
     "title": "Senior Thesis in Economics",
     "campus": "cmc",
     "credits": 3.0
@@ -38046,12 +49038,6 @@
     "credits": 3.0
   },
   {
-    "code": "XEEP190",
-    "title": "Senior Thesis in EEP",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "XEEP190A",
     "title": "Senior Thesis in EEP",
     "campus": "cmc",
@@ -38059,6 +49045,12 @@
   },
   {
     "code": "XEEP190B",
+    "title": "Senior Thesis in EEP",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "XEEP190",
     "title": "Senior Thesis in EEP",
     "campus": "cmc",
     "credits": 3.0
@@ -38088,12 +49080,6 @@
     "credits": 3.0
   },
   {
-    "code": "XFLM190",
-    "title": "Senior Thesis in Film Studies",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "XFLM190A",
     "title": "Senior Thesis in Film Studies",
     "campus": "cmc",
@@ -38101,6 +49087,12 @@
   },
   {
     "code": "XFLM190B",
+    "title": "Senior Thesis in Film Studies",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "XFLM190",
     "title": "Senior Thesis in Film Studies",
     "campus": "cmc",
     "credits": 3.0
@@ -38118,12 +49110,6 @@
     "credits": 3.0
   },
   {
-    "code": "XFRE190",
-    "title": "Senior Thesis in French",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "XFRE190A",
     "title": "Senior Thesis in French",
     "campus": "cmc",
@@ -38131,6 +49117,12 @@
   },
   {
     "code": "XFRE190B",
+    "title": "Senior Thesis in French",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "XFRE190",
     "title": "Senior Thesis in French",
     "campus": "cmc",
     "credits": 3.0
@@ -38154,12 +49146,6 @@
     "credits": 3.0
   },
   {
-    "code": "XGOV190",
-    "title": "Senior Thesis in Government",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "XGOV190A",
     "title": "Senior Thesis in Government",
     "campus": "cmc",
@@ -38167,6 +49153,12 @@
   },
   {
     "code": "XGOV190B",
+    "title": "Senior Thesis in Government",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "XGOV190",
     "title": "Senior Thesis in Government",
     "campus": "cmc",
     "credits": 3.0
@@ -38184,12 +49176,6 @@
     "credits": 3.0
   },
   {
-    "code": "XHIS190",
-    "title": "Senior Thesis in History",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "XHIS190A",
     "title": "Senior Thesis in History",
     "campus": "cmc",
@@ -38197,6 +49183,12 @@
   },
   {
     "code": "XHIS190B",
+    "title": "Senior Thesis in History",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "XHIS190",
     "title": "Senior Thesis in History",
     "campus": "cmc",
     "credits": 3.0
@@ -38220,12 +49212,6 @@
     "credits": 3.0
   },
   {
-    "code": "XLEG190",
-    "title": "Senior Thesis in Legal Studies",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "XLEG190A",
     "title": "Senior Thesis in Legal Studies",
     "campus": "cmc",
@@ -38238,14 +49224,14 @@
     "credits": 3.0
   },
   {
-    "code": "XLEG192",
+    "code": "XLEG190",
     "title": "Senior Thesis in Legal Studies",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "XLIT190",
-    "title": "Senior Thesis in Literature",
+    "code": "XLEG192",
+    "title": "Senior Thesis in Legal Studies",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -38257,6 +49243,12 @@
   },
   {
     "code": "XLIT190B",
+    "title": "Senior Thesis in Literature",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "XLIT190",
     "title": "Senior Thesis in Literature",
     "campus": "cmc",
     "credits": 3.0
@@ -38274,12 +49266,6 @@
     "credits": 3.0
   },
   {
-    "code": "XMAT190",
-    "title": "Senior Thesis in Mathematics",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "XMAT190A",
     "title": "Senior Thesis in Mathematics",
     "campus": "cmc",
@@ -38287,6 +49273,12 @@
   },
   {
     "code": "XMAT190B",
+    "title": "Senior Thesis in Mathematics",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "XMAT190",
     "title": "Senior Thesis in Mathematics",
     "campus": "cmc",
     "credits": 3.0
@@ -38304,12 +49296,6 @@
     "credits": 3.0
   },
   {
-    "code": "XMDS190",
-    "title": "Sr Thesis in Media Studies",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "XMDS190A",
     "title": "Sr Thesis in Media Studies",
     "campus": "cmc",
@@ -38317,6 +49303,18 @@
   },
   {
     "code": "XMDS190B",
+    "title": "Sr Thesis in Media Studies",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "XMDS190",
+    "title": "Senior Thesis in Media Studies",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "XMDS190",
     "title": "Sr Thesis in Media Studies",
     "campus": "cmc",
     "credits": 3.0
@@ -38358,12 +49356,6 @@
     "credits": 3.0
   },
   {
-    "code": "XPHI190",
-    "title": "Senior Thesis in Philosophy",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "XPHI190A",
     "title": "Senior Thesis in Philosophy",
     "campus": "cmc",
@@ -38371,6 +49363,12 @@
   },
   {
     "code": "XPHI190B",
+    "title": "Senior Thesis in Philosophy",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "XPHI190",
     "title": "Senior Thesis in Philosophy",
     "campus": "cmc",
     "credits": 3.0
@@ -38388,12 +49386,6 @@
     "credits": 3.0
   },
   {
-    "code": "XPSY190",
-    "title": "Senior Thesis in Psychology",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "XPSY190A",
     "title": "Senior Thesis in Psychology",
     "campus": "cmc",
@@ -38401,6 +49393,12 @@
   },
   {
     "code": "XPSY190B",
+    "title": "Senior Thesis in Psychology",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "XPSY190",
     "title": "Senior Thesis in Psychology",
     "campus": "cmc",
     "credits": 3.0
@@ -38418,12 +49416,6 @@
     "credits": 3.0
   },
   {
-    "code": "XRLS190",
-    "title": "Senior Thesis in Relig Studies",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "XRLS190A",
     "title": "Senior Thesis in Relig Studies",
     "campus": "cmc",
@@ -38431,6 +49423,12 @@
   },
   {
     "code": "XRLS190B",
+    "title": "Senior Thesis in Relig Studies",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "XRLS190",
     "title": "Senior Thesis in Relig Studies",
     "campus": "cmc",
     "credits": 3.0
@@ -38448,12 +49446,6 @@
     "credits": 3.0
   },
   {
-    "code": "XSPA190",
-    "title": "Senior Thesis in Spanish",
-    "campus": "cmc",
-    "credits": 3.0
-  },
-  {
     "code": "XSPA190A",
     "title": "Senior Thesis in Spanish",
     "campus": "cmc",
@@ -38461,6 +49453,12 @@
   },
   {
     "code": "XSPA190B",
+    "title": "Senior Thesis in Spanish",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "XSPA190",
     "title": "Senior Thesis in Spanish",
     "campus": "cmc",
     "credits": 3.0

--- a/src/static/allCourses.json
+++ b/src/static/allCourses.json
@@ -7,7 +7,7 @@
   },
   {
     "code": "AAA100",
-    "title": "Test Class--Ignore",
+    "title": "Test Course I",
     "campus": "pz",
     "credits": 3.0
   },
@@ -21,6 +21,12 @@
     "code": "AAA102",
     "title": "Test Course 3 - Ignore",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "ABROAD",
+    "title": "Semester Abroad",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -122,13 +128,13 @@
   {
     "code": "AFRI010A",
     "title": "Intro to Africana Studies",
-    "campus": "cmc",
+    "campus": "sc",
     "credits": 3.0
   },
   {
     "code": "AFRI010B",
     "title": "Research Methods",
-    "campus": "cmc",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -176,7 +182,7 @@
   {
     "code": "AFRI121",
     "title": "Africana Philosophy",
-    "campus": "cmc",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -193,13 +199,13 @@
   },
   {
     "code": "AFRI144A",
-    "title": "Black Women, Feminism(s) & Arts",
+    "title": "Black Women Feminisms Soc Chnge",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "AFRI149",
-    "title": "Africana Political Theory",
+    "title": "Black Political Theory in the US",
     "campus": "sc",
     "credits": 3.0
   },
@@ -217,14 +223,14 @@
   },
   {
     "code": "AFRI190",
-    "title": "Senior Thesis",
-    "campus": "pz",
+    "title": "Senior Seminar",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "AFRI191",
-    "title": "Senior Thesis:Africana Studies",
-    "campus": "sc",
+    "title": "Senior Thesis",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -458,7 +464,7 @@
   {
     "code": "AMST103",
     "title": "Intro to American Cultures",
-    "campus": "sc",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -530,7 +536,7 @@
   {
     "code": "AMST180",
     "title": "American Studies Seminar",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -541,8 +547,8 @@
   },
   {
     "code": "AMST191",
-    "title": "Senior Thesis: American Studies",
-    "campus": "sc",
+    "title": "Senior Thesis",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -607,8 +613,8 @@
   },
   {
     "code": "ANTH002",
-    "title": "Intro Sociocultural Anthropology",
-    "campus": "sc",
+    "title": "Intro to Sociocultural Anth",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -649,8 +655,8 @@
   },
   {
     "code": "ANTH020",
-    "title": "Anthropology of Latin America",
-    "campus": "sc",
+    "title": "Human Histories:Onset to 1500ish",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -673,8 +679,8 @@
   },
   {
     "code": "ANTH025",
-    "title": "Anthro of the Middle East",
-    "campus": "sc",
+    "title": "Anthropology of the Middle East",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -745,8 +751,8 @@
   },
   {
     "code": "ANTH047",
-    "title": "Anthropology of Religion",
-    "campus": "sc",
+    "title": "Economic Anthropology",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -775,25 +781,25 @@
   },
   {
     "code": "ANTH052",
-    "title": "Indigenous Societies",
-    "campus": "pz",
+    "title": "Human Sexuality",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ANTH053",
-    "title": "Language and Globalization",
+    "title": "Language, Thought, and Culture",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ANTH055",
-    "title": "Brazil: An Introduction",
-    "campus": "pz",
+    "title": "Power, Politics & Culture",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ANTH056",
-    "title": "Anthropology of Sound",
+    "title": "Run to the Forest",
     "campus": "pz",
     "credits": 3.0
   },
@@ -943,7 +949,7 @@
   },
   {
     "code": "ANTH098",
-    "title": "Palestine and Israel",
+    "title": "State & History:The Israeli Case",
     "campus": "pz",
     "credits": 3.0
   },
@@ -967,8 +973,8 @@
   },
   {
     "code": "ANTH102",
-    "title": "Museums and Material Culture",
-    "campus": "pz",
+    "title": "Applied Anthropology",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -991,8 +997,8 @@
   },
   {
     "code": "ANTH105",
-    "title": "Field Methods in Anthropology",
-    "campus": "sc",
+    "title": "Mthds in Anthropological Inquiry",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -1003,13 +1009,13 @@
   },
   {
     "code": "ANTH107",
-    "title": "Medical Anthro & Global Health",
-    "campus": "sc",
+    "title": "Medical Anthropology",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ANTH108",
-    "title": "Kinship, Family, Sexuality",
+    "title": "Kinship & Social Organization",
     "campus": "sc",
     "credits": 3.0
   },
@@ -1021,26 +1027,26 @@
   },
   {
     "code": "ANTH110",
-    "title": "Nature and Society in Amazonia",
-    "campus": "pz",
+    "title": "Knowledge,Belief,Cultural Practs",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "ANTH111",
-    "title": "Historical Archaeology",
-    "campus": "pz",
+    "title": "Intro Anth Science & Technology",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "ANTH112",
-    "title": "Energy & Humnty, Past, Prsnt, Ft",
+    "title": "Intro to China, Tibet & Nepal",
     "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "ANTH113",
     "title": "Ethnographic Tales of the City",
-    "campus": "sc",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -1051,8 +1057,8 @@
   },
   {
     "code": "ANTH115",
-    "title": "Stuff:Social Life of Commodities",
-    "campus": "sc",
+    "title": "War and Conflict",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -1075,7 +1081,7 @@
   },
   {
     "code": "ANTH119",
-    "title": "East Asia in Ethnography & Film",
+    "title": "East Asia and Global Futures",
     "campus": "sc",
     "credits": 3.0
   },
@@ -1105,8 +1111,8 @@
   },
   {
     "code": "ANTH124",
-    "title": "Illness/Health: Anthro Perspect",
-    "campus": "pz",
+    "title": "The Seacoast in Prehistory",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -1123,7 +1129,7 @@
   },
   {
     "code": "ANTH127",
-    "title": "Settler Colonialism",
+    "title": "Asian Amer in Ethnography/Film",
     "campus": "sc",
     "credits": 3.0
   },
@@ -1135,14 +1141,14 @@
   },
   {
     "code": "ANTH129",
-    "title": "Politics of Public Art",
-    "campus": "sc",
+    "title": "Native California",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ANTH130",
-    "title": "Anthro of Gender and Health",
-    "campus": "sc",
+    "title": "Sexuality/Sexual Poli Mid-East",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -1159,8 +1165,8 @@
   },
   {
     "code": "ANTH133",
-    "title": "Colonialism & Postcol Theory",
-    "campus": "sc",
+    "title": "Indians in Action",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -1171,8 +1177,8 @@
   },
   {
     "code": "ANTH135",
-    "title": "Plants and Peoples",
-    "campus": "pz",
+    "title": "The Social Life of Media",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -1207,8 +1213,8 @@
   },
   {
     "code": "ANTH142",
-    "title": "Culture & Politics Latin America",
-    "campus": "sc",
+    "title": "Ethnographic Approaches to Japan",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -1219,7 +1225,7 @@
   },
   {
     "code": "ANTH145",
-    "title": "Mesoamerican Archaeology",
+    "title": "Cultural Ecology",
     "campus": "po",
     "credits": 3.0
   },
@@ -1231,7 +1237,7 @@
   },
   {
     "code": "ANTH150",
-    "title": "Anthropology of Religion",
+    "title": "Understanding Religion",
     "campus": "po",
     "credits": 3.0
   },
@@ -1249,14 +1255,14 @@
   },
   {
     "code": "ANTH153",
-    "title": "History Anthropological Theory",
-    "campus": "sc",
+    "title": "Theory in Anthropology",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ANTH155",
-    "title": "World Nexus: Special Topic",
-    "campus": "pz",
+    "title": "Globalization",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -1285,14 +1291,14 @@
   },
   {
     "code": "ANTH160",
-    "title": "Native American Women's Arts",
-    "campus": "pz",
+    "title": "Human Nutritional Adaptation",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ANTH161",
-    "title": "Greek Art and Archaeology",
-    "campus": "pz",
+    "title": "Experimental Archaeology",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -1315,8 +1321,8 @@
   },
   {
     "code": "ANTH168",
-    "title": "Prehist Humans and Environments",
-    "campus": "pz",
+    "title": "Sem: Gay & Lesbian Ethnography",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -1387,7 +1393,7 @@
   },
   {
     "code": "ANTH189L",
-    "title": "Linguistic Anthropology",
+    "title": "Production & Reception of Icons",
     "campus": "po",
     "credits": 3.0
   },
@@ -1411,20 +1417,20 @@
   },
   {
     "code": "ANTH190",
-    "title": "Senior Seminar",
-    "campus": "sc",
+    "title": "Senior Research Design Seminar",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ANTH191",
-    "title": "Senior Thesis Seminar",
-    "campus": "sc",
+    "title": "Senior Thesis",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ANTH191A",
-    "title": "Sr Thesis: Sociocultural Track",
-    "campus": "sc",
+    "title": "Senior Thesis: Sociocultural",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -1441,8 +1447,8 @@
   },
   {
     "code": "ANTH192",
-    "title": "Senior Thesis & Project Seminar",
-    "campus": "pz",
+    "title": "Senior Project",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -1489,8 +1495,8 @@
   },
   {
     "code": "ANTH199",
-    "title": "Independent St: Anthropology",
-    "campus": "sc",
+    "title": "Senior Thesis",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -1515,6 +1521,42 @@
     "code": "ANTH999",
     "title": "Independent Study",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "APEH",
+    "title": "AP European History",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "APFRENCHLIT",
+    "title": "AP French Literature Exam",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "APGERMLIT",
+    "title": "AP German Literature Exam",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "APSPANLIT",
+    "title": "AP Spanish Literature Exam",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "APUS",
+    "title": "AP US History",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "APWH",
+    "title": "AP World History",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -1681,13 +1723,13 @@
   },
   {
     "code": "ARCN110",
-    "title": "Artists Materials:Ancient/Modern",
+    "title": "Artists Materials,Ancient+Modern",
     "campus": "sc",
     "credits": 3.0
   },
   {
     "code": "ARCN115",
-    "title": "Art & Crime: Fakes & Forensics",
+    "title": "Art&Crime: Fakes & Forensics",
     "campus": "sc",
     "credits": 3.0
   },
@@ -1813,8 +1855,8 @@
   },
   {
     "code": "ARHI051C",
-    "title": "Intro Art Hist: 1200 to Present",
-    "campus": "pz",
+    "title": "Intro Art Hist:Rnsscnce to Mod",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -1861,8 +1903,8 @@
   },
   {
     "code": "ARHI131",
-    "title": "Border Art",
-    "campus": "po",
+    "title": "History of Landscape Photography",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -1873,8 +1915,8 @@
   },
   {
     "code": "ARHI133",
-    "title": "Indians in Action",
-    "campus": "pz",
+    "title": "Art, Conquest and Colonization",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -1951,8 +1993,8 @@
   },
   {
     "code": "ARHI150",
-    "title": "The Arts of China",
-    "campus": "sc",
+    "title": "Picasso",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -1975,8 +2017,8 @@
   },
   {
     "code": "ARHI154",
-    "title": "Japanese Prints",
-    "campus": "sc",
+    "title": "Modern Art 1950-1970",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -2006,7 +2048,7 @@
   {
     "code": "ARHI159",
     "title": "History of Art History",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -2041,7 +2083,7 @@
   },
   {
     "code": "ARHI166",
-    "title": "Crusades:Cross-Cultural History",
+    "title": "Crusades: A Cultural History",
     "campus": "po",
     "credits": 3.0
   },
@@ -2089,8 +2131,8 @@
   },
   {
     "code": "ARHI176",
-    "title": "Neo-Classicism to Impressionism",
-    "campus": "sc",
+    "title": "Italian Cities",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -2107,8 +2149,8 @@
   },
   {
     "code": "ARHI179",
-    "title": "Modern Arch/Sustainability",
-    "campus": "po",
+    "title": "Special Topics in Art History",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -2131,7 +2173,7 @@
   },
   {
     "code": "ARHI180",
-    "title": "Archi Models Monuments Miniature",
+    "title": "Early 20C European Avant-Gardes",
     "campus": "sc",
     "credits": 3.0
   },
@@ -2143,8 +2185,8 @@
   },
   {
     "code": "ARHI181",
-    "title": "Art from 1945-1989",
-    "campus": "sc",
+    "title": "Modern Into Contemporary",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -2186,12 +2228,12 @@
   {
     "code": "ARHI186A",
     "title": "Theories of Contemporary Art",
-    "campus": "pz",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ARHI186B",
-    "title": "Art and Animals",
+    "title": "Topics: Contemporary Art",
     "campus": "pz",
     "credits": 3.0
   },
@@ -2245,8 +2287,8 @@
   },
   {
     "code": "ARHI186L",
-    "title": "Seminar: The Artist",
-    "campus": "sc",
+    "title": "Critical Race Thry/Representatn",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -2275,13 +2317,13 @@
   },
   {
     "code": "ARHI186T",
-    "title": "THINGS",
-    "campus": "pz",
+    "title": "Art and Time",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ARHI186W",
-    "title": "Interrog Whiteness:Race,Sex,Rep",
+    "title": "Whiteness:Race,Sex,Representatn",
     "campus": "po",
     "credits": 3.0
   },
@@ -2305,7 +2347,7 @@
   },
   {
     "code": "ARHI189",
-    "title": "European Modernism",
+    "title": "European Modernism 1840-1940",
     "campus": "sc",
     "credits": 3.0
   },
@@ -2323,14 +2365,14 @@
   },
   {
     "code": "ARHI190",
-    "title": "Senior Seminar in Art History",
+    "title": "Senior Seminar",
     "campus": "sc",
     "credits": 3.0
   },
   {
     "code": "ARHI191",
-    "title": "Senior Thesis in Art History",
-    "campus": "sc",
+    "title": "Senior Thesis - Art History",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -2342,7 +2384,7 @@
   {
     "code": "ARHI191B",
     "title": "Senior Thesis in Art History",
-    "campus": "sc",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -2353,8 +2395,8 @@
   },
   {
     "code": "ARHI198",
-    "title": "Independent Internship",
-    "campus": "sc",
+    "title": "Summer Reading & Research",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -2448,6 +2490,12 @@
     "credits": 3.0
   },
   {
+    "code": "ART",
+    "title": "Art: Directed Readings",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "ART001",
     "title": "Introduction to Studio Art",
     "campus": "pz",
@@ -2503,8 +2551,8 @@
   },
   {
     "code": "ART020",
-    "title": "A Philosopher & An Artist",
-    "campus": "pz",
+    "title": "Black and White Photography",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -2551,8 +2599,8 @@
   },
   {
     "code": "ART033",
-    "title": "Fiber Studio",
-    "campus": "po",
+    "title": "Photography",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -2623,8 +2671,8 @@
   },
   {
     "code": "ART101",
-    "title": "Introduction to Painting",
-    "campus": "sc",
+    "title": "Further Works in Mixed Media",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -2683,8 +2731,8 @@
   },
   {
     "code": "ART109",
-    "title": "Adobe & Brick Oven Construction",
-    "campus": "pz",
+    "title": "Painting as Experiment",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -2695,8 +2743,8 @@
   },
   {
     "code": "ART111",
-    "title": "Intermediate Painting",
-    "campus": "pz",
+    "title": "Topics in Contemporary Painting",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -2707,8 +2755,8 @@
   },
   {
     "code": "ART113",
-    "title": "Adv Mixed Media: Sci & Landscape",
-    "campus": "sc",
+    "title": "Drawing Workshop",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -2719,14 +2767,14 @@
   },
   {
     "code": "ART115",
-    "title": "Food and Painting",
-    "campus": "pz",
+    "title": "Self Publishing for Artists",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ART116",
-    "title": "Moldmaking",
-    "campus": "pz",
+    "title": "Advanced Photography",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -2743,8 +2791,8 @@
   },
   {
     "code": "ART119",
-    "title": "The Ceramic Object and Food",
-    "campus": "pz",
+    "title": "Landscape/Placescape/Spacescape",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -2755,8 +2803,8 @@
   },
   {
     "code": "ART120",
-    "title": "Introduction to Wheel Throwing",
-    "campus": "sc",
+    "title": "Photographing People",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -2767,32 +2815,32 @@
   },
   {
     "code": "ART122",
-    "title": "Systems:Expanded Ceramic Process",
+    "title": "Intermediate & Advanced Ceramics",
     "campus": "sc",
     "credits": 3.0
   },
   {
     "code": "ART123",
-    "title": "Figurative Ceramic Sculpture",
-    "campus": "sc",
+    "title": "Documentary Photography",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ART124",
-    "title": "Documenting Change with Clay",
-    "campus": "sc",
+    "title": "Sound Art",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ART125",
-    "title": "Sculpture",
-    "campus": "sc",
+    "title": "Intrm & Adv Darkroom Photography",
+    "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "ART126",
-    "title": "Intermediate Sculpture",
-    "campus": "sc",
+    "title": "Spcl Tpcs: Lrge Frmt Photography",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -2804,7 +2852,7 @@
   {
     "code": "ART127",
     "title": "Sculpture Practicum",
-    "campus": "sc",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -2815,26 +2863,26 @@
   },
   {
     "code": "ART128",
-    "title": "Three-Dimensional Art",
-    "campus": "sc",
+    "title": "Installation:Site, Time, Context",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ART129",
-    "title": "Clay and Public Space",
-    "campus": "sc",
+    "title": "Performance in Contemporary Art",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ART130",
-    "title": "Clay/Collaboration/Cooperation",
-    "campus": "sc",
+    "title": "Artist as Curator and Organizer",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ART131",
-    "title": "Beginning Printmaking",
-    "campus": "sc",
+    "title": "Sculptural Funct & Concep Design",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -2851,8 +2899,8 @@
   },
   {
     "code": "ART133",
-    "title": "Advanced Printmaking",
-    "campus": "sc",
+    "title": "Mural Painting",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -2863,7 +2911,7 @@
   },
   {
     "code": "ART135",
-    "title": "Letterpress Printing",
+    "title": "Typography & Book Arts",
     "campus": "sc",
     "credits": 3.0
   },
@@ -2875,7 +2923,7 @@
   },
   {
     "code": "ART137",
-    "title": "Social Justice & Book Arts",
+    "title": "Race & Identity: Artists' Books",
     "campus": "sc",
     "credits": 3.0
   },
@@ -2911,7 +2959,7 @@
   },
   {
     "code": "ART143",
-    "title": "Adv Digital Art",
+    "title": "Int & Adv Digital Photography",
     "campus": "sc",
     "credits": 3.0
   },
@@ -2923,7 +2971,7 @@
   },
   {
     "code": "ART145",
-    "title": "Intro B/W Darkroom Photo",
+    "title": "Intro Black & White Photography",
     "campus": "sc",
     "credits": 3.0
   },
@@ -2935,8 +2983,8 @@
   },
   {
     "code": "ART147",
-    "title": "Int/Adv Digital Photography",
-    "campus": "sc",
+    "title": "Community, Ecology and Design",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -2947,7 +2995,7 @@
   },
   {
     "code": "ART149",
-    "title": "Intermediate Video Art",
+    "title": "Intermediate and Advanced Video",
     "campus": "sc",
     "credits": 3.0
   },
@@ -3061,7 +3109,7 @@
   },
   {
     "code": "ART181G",
-    "title": "Beauty & Abject: Race/Gender/Art",
+    "title": "From Beauty to the Abject",
     "campus": "sc",
     "credits": 3.0
   },
@@ -3115,13 +3163,13 @@
   },
   {
     "code": "ART192",
-    "title": "Sr Project & Seminar:Studio Arts",
-    "campus": "sc",
+    "title": "Advanced Projects in Art",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ART193",
-    "title": "Advanced Senior Project in Art",
+    "title": "Adv Sr Proj+Sem in Studio Art",
     "campus": "sc",
     "credits": 3.0
   },
@@ -3133,14 +3181,14 @@
   },
   {
     "code": "ART196",
-    "title": "Curatorial Apprenticeship",
+    "title": "Artist Apprenticeship",
     "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "ART197",
-    "title": "Art in Los Angeles Now",
-    "campus": "pz",
+    "title": "Independent Study: Art",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -3151,8 +3199,8 @@
   },
   {
     "code": "ART199",
-    "title": "Independent Study:  Studio Arts",
-    "campus": "sc",
+    "title": "Senior Projects in Art",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -3217,7 +3265,7 @@
   },
   {
     "code": "ASAM022",
-    "title": "Healing Justice",
+    "title": "Asian American Wellness",
     "campus": "pz",
     "credits": 3.0
   },
@@ -3265,13 +3313,13 @@
   },
   {
     "code": "ASAM086",
-    "title": "Social Documentation",
-    "campus": "pz",
+    "title": "Social Documentation/Asian-Amer",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "ASAM088",
-    "title": "Thich Nhat Hanh",
+    "title": "China: Gender Cosmology & State",
     "campus": "pz",
     "credits": 3.0
   },
@@ -3283,8 +3331,8 @@
   },
   {
     "code": "ASAM090",
-    "title": "Community Studies",
-    "campus": "pz",
+    "title": "Asian Amer+Multiracial Community",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -3319,7 +3367,7 @@
   },
   {
     "code": "ASAM102",
-    "title": "Social Responsibility Praxis",
+    "title": "Fieldwork",
     "campus": "pz",
     "credits": 3.0
   },
@@ -3343,7 +3391,7 @@
   },
   {
     "code": "ASAM105B",
-    "title": "Zines in the Asian Diaspora",
+    "title": "Zines In The Asian Diaspora",
     "campus": "pz",
     "credits": 3.0
   },
@@ -3373,8 +3421,8 @@
   },
   {
     "code": "ASAM111",
-    "title": "Pacific Islanders & Education",
-    "campus": "pz",
+    "title": "Pacific Islanders and Education",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -3385,13 +3433,13 @@
   },
   {
     "code": "ASAM115",
-    "title": "Theory and Methods",
+    "title": "Methodologies",
     "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "ASAM120",
-    "title": "Sex Work in Asia / America",
+    "title": "Critical Fil Am Studies",
     "campus": "pz",
     "credits": 3.0
   },
@@ -3403,8 +3451,8 @@
   },
   {
     "code": "ASAM125",
-    "title": "Asian American Hist: 1850-Presnt",
-    "campus": "pz",
+    "title": "Intro Asian Amer Hist:1850-Pres",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -3427,7 +3475,7 @@
   },
   {
     "code": "ASAM135",
-    "title": "Race Empire Filipinx America",
+    "title": "Race Empire Filipina/o America",
     "campus": "pz",
     "credits": 3.0
   },
@@ -3446,13 +3494,13 @@
   {
     "code": "ASAM150",
     "title": "Contemp Asian American Issues",
-    "campus": "pz",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "ASAM160",
     "title": "Asian American Women's Experienc",
-    "campus": "pz",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -3505,8 +3553,8 @@
   },
   {
     "code": "ASAM179E",
-    "title": "Asian/Americans & Popular Cultre",
-    "campus": "pz",
+    "title": "Asian/Americans & PopularCulture",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -3547,8 +3595,8 @@
   },
   {
     "code": "ASAM190A",
-    "title": "Senior Seminar",
-    "campus": "pz",
+    "title": "Asian Amer Studies Senior Sem",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -3571,8 +3619,8 @@
   },
   {
     "code": "ASAM191",
-    "title": "Senior Thesis:Asian American St",
-    "campus": "sc",
+    "title": "Senior Thesis Asian Amer Studies",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -3625,8 +3673,8 @@
   },
   {
     "code": "ASIA191",
-    "title": "Senior Thesis: Asian Studies",
-    "campus": "sc",
+    "title": "Senior Thesis",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -3667,19 +3715,19 @@
   },
   {
     "code": "ASTR001",
-    "title": "Lab, Introductory Astronomy",
+    "title": "Introductory Astronomy w/Lab",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ASTR002",
-    "title": "Intro to Galax & Cosmology Lab",
+    "title": "Intro to Galaxies & Cosmology",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ASTR003",
-    "title": "Life in the Universe Laboratory",
+    "title": "Life in the Universe",
     "campus": "po",
     "credits": 3.0
   },
@@ -3691,7 +3739,7 @@
   },
   {
     "code": "ASTR009",
-    "title": "Lab, Cosmic Origins",
+    "title": "Cosmic Origins",
     "campus": "po",
     "credits": 3.0
   },
@@ -3703,14 +3751,14 @@
   },
   {
     "code": "ASTR051",
-    "title": "Advanced Intr. Astronomy Lab",
+    "title": "Advanced Introductory Astronomy",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ASTR062",
     "title": "Introduction to Astrophysics",
-    "campus": "po",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -3727,8 +3775,8 @@
   },
   {
     "code": "ASTR101",
-    "title": "Lab, Observational Astrophysics",
-    "campus": "po",
+    "title": "Observational Astronomy",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -3740,19 +3788,19 @@
   {
     "code": "ASTR121",
     "title": "Cosmolgy/Extragalactic Astrophys",
-    "campus": "po",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "ASTR122",
-    "title": "High-Energy Astrophysics",
-    "campus": "po",
+    "title": "High Energy Astrophysics",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "ASTR123",
-    "title": "Stellar Structure and Evolution",
-    "campus": "po",
+    "title": "Stellar Structure & Evolution",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -3764,7 +3812,7 @@
   {
     "code": "ASTR125",
     "title": "Galactic Astronomy",
-    "campus": "po",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -3800,6 +3848,12 @@
   {
     "code": "ASTR199RAPO",
     "title": "Astronomy:Research Assistantship",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "AWAY",
+    "title": "F/T Enrollment - Away from PO",
     "campus": "po",
     "credits": 3.0
   },
@@ -3841,7 +3895,7 @@
   },
   {
     "code": "BIOL002A",
-    "title": "Science, Power, & Identity w/Lab",
+    "title": "Biology, Gender & Society w/ Lab",
     "campus": "po",
     "credits": 3.0
   },
@@ -4081,8 +4135,8 @@
   },
   {
     "code": "BIOL082L",
-    "title": "Plant Biotechnology Greener Wrld",
-    "campus": "pz",
+    "title": "Plant Biotech in Greener World",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -4129,8 +4183,8 @@
   },
   {
     "code": "BIOL103",
-    "title": "Invasion Biology",
-    "campus": "po",
+    "title": "Comparative Physiology Lab",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -4141,13 +4195,13 @@
   },
   {
     "code": "BIOL106",
-    "title": "Aquatic Ecology Lab",
+    "title": "Aquatic Ecology",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "BIOL107",
-    "title": "Avian Ecology w/Lab",
+    "title": "Avian Ecology",
     "campus": "po",
     "credits": 3.0
   },
@@ -4159,14 +4213,14 @@
   },
   {
     "code": "BIOL109",
-    "title": "Lab, Molecular Evolution",
-    "campus": "po",
+    "title": "Evolutionary Biology",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "BIOL110",
-    "title": "Biochemistry for Pre-Health",
-    "campus": "sc",
+    "title": "Experimental Ecology Laboratory",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -4177,7 +4231,7 @@
   },
   {
     "code": "BIOL112",
-    "title": "Lab, Advanced Animal Ecology",
+    "title": "Advanced Animal Ecology",
     "campus": "po",
     "credits": 3.0
   },
@@ -4195,7 +4249,7 @@
   },
   {
     "code": "BIOL116",
-    "title": "Ecology/Evolution of Plants Lab",
+    "title": "Ecology/Evol of Plants w/Lab",
     "campus": "po",
     "credits": 3.0
   },
@@ -4213,8 +4267,8 @@
   },
   {
     "code": "BIOL121",
-    "title": "Lab, Insect Ecology & Behavior",
-    "campus": "po",
+    "title": "Marine Ecology",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -4237,7 +4291,7 @@
   },
   {
     "code": "BIOL125",
-    "title": "Lab, Animal Behavior",
+    "title": "Animal Behavior with Laboratory",
     "campus": "po",
     "credits": 3.0
   },
@@ -4261,7 +4315,7 @@
   },
   {
     "code": "BIOL131",
-    "title": "Lab, Invertebrate Biology",
+    "title": "Invertebrate Biology w/ Lab",
     "campus": "po",
     "credits": 3.0
   },
@@ -4279,7 +4333,7 @@
   },
   {
     "code": "BIOL132",
-    "title": "Lab, Vertebrate Biology",
+    "title": "Vertebrate Biology with Lab",
     "campus": "po",
     "credits": 3.0
   },
@@ -4315,7 +4369,7 @@
   },
   {
     "code": "BIOL138L",
-    "title": "Appl Ecol + Conservation Lab",
+    "title": "Appl Ecol + Conservation w/Lab",
     "campus": "sc",
     "credits": 3.0
   },
@@ -4327,8 +4381,8 @@
   },
   {
     "code": "BIOL140",
-    "title": "Lab, Animal Physiology",
-    "campus": "po",
+    "title": "Selected Topics in Neuroscience",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -4357,8 +4411,8 @@
   },
   {
     "code": "BIOL144",
-    "title": "Lab, Comparative Endocrinology",
-    "campus": "po",
+    "title": "Drugs and Molecular Medicine",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -4375,8 +4429,8 @@
   },
   {
     "code": "BIOL147",
-    "title": "Lab, Biochem: Metabolomics & Reg",
-    "campus": "po",
+    "title": "Biogeography",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -4423,8 +4477,8 @@
   },
   {
     "code": "BIOL154",
-    "title": "Animal Behavior",
-    "campus": "sc",
+    "title": "Biostatistics",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -4471,20 +4525,20 @@
   },
   {
     "code": "BIOL160",
-    "title": "Immunology",
-    "campus": "po",
+    "title": "Molecular Immunology",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "BIOL161",
-    "title": "Immunology Laboratory",
-    "campus": "po",
+    "title": "Research Problems in Biology",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "BIOL162",
-    "title": "Genetic Analysis",
-    "campus": "po",
+    "title": "Research Problems in Biology",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -4495,7 +4549,7 @@
   },
   {
     "code": "BIOL163",
-    "title": "Cell Biology Laboratory",
+    "title": "Advanced Cell Biology with Lab",
     "campus": "po",
     "credits": 3.0
   },
@@ -4507,14 +4561,14 @@
   },
   {
     "code": "BIOL164",
-    "title": "Lab, Genetic Reg in Eukaryotes",
-    "campus": "po",
+    "title": "Genetics",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "BIOL165",
-    "title": "Genetic Regulation Seminar",
-    "campus": "po",
+    "title": "Adv Topics: Environmental Biol",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -4531,14 +4585,14 @@
   },
   {
     "code": "BIOL166",
-    "title": "Lab, Plant Physiology",
-    "campus": "po",
+    "title": "Cell Biology and Genetics Lab",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "BIOL167",
-    "title": "Lab, Microbial Genetics",
-    "campus": "po",
+    "title": "Sensory Evolution",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -4555,7 +4609,7 @@
   },
   {
     "code": "BIOL169",
-    "title": "Lab, Developmental Biology",
+    "title": "Developmental Biology w/Lab",
     "campus": "po",
     "credits": 3.0
   },
@@ -4579,8 +4633,8 @@
   },
   {
     "code": "BIOL171",
-    "title": "Biology of Cancer",
-    "campus": "sc",
+    "title": "Analysis of Aquatic Ecosystems",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -4591,8 +4645,8 @@
   },
   {
     "code": "BIOL173",
-    "title": "Lab, Genomics and Bioinformatics",
-    "campus": "po",
+    "title": "Analysis Terrestrial Ecosystems",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -4603,8 +4657,8 @@
   },
   {
     "code": "BIOL174",
-    "title": "Lab, Prgrm for Life Sciences",
-    "campus": "po",
+    "title": "Biophysics",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -4645,8 +4699,8 @@
   },
   {
     "code": "BIOL181",
-    "title": "Fire Ecology in So CA w/ Lab",
-    "campus": "po",
+    "title": "Neurological Disorders",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -4663,8 +4717,8 @@
   },
   {
     "code": "BIOL183",
-    "title": "Nutritional Biology",
-    "campus": "sc",
+    "title": "Topics in Physiology",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -4681,8 +4735,8 @@
   },
   {
     "code": "BIOL185",
-    "title": "Biochemical Physiology",
-    "campus": "sc",
+    "title": "Special Topics in Biology",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -4735,8 +4789,8 @@
   },
   {
     "code": "BIOL187",
-    "title": "Special Topics in Biology",
-    "campus": "sc",
+    "title": "HIV/AIDS: Sci, Society & Service",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -4819,8 +4873,8 @@
   },
   {
     "code": "BIOL189L",
-    "title": "Emerging Infectious Diseases",
-    "campus": "po",
+    "title": "Sr Thes Summer Rsrch Proj in Bio",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -4897,8 +4951,8 @@
   },
   {
     "code": "BIOL191",
-    "title": "Senior Grant Proposal",
-    "campus": "po",
+    "title": "Biology Colloquium",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -4957,14 +5011,14 @@
   },
   {
     "code": "BIOL198",
-    "title": "Independent Internship",
-    "campus": "sc",
+    "title": "Directed Reading in Biology",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "BIOL199",
-    "title": "Senior Thesis",
-    "campus": "pz",
+    "title": "Independent Study in Biology",
+    "campus": "cgu",
     "credits": 3.0
   },
   {
@@ -4995,6 +5049,30 @@
     "code": "BIOL999",
     "title": "Independent Study",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOLELECTHM",
+    "title": "Biology Major Elective",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOLLAB",
+    "title": "Biology Lab Requirement",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOLSEM",
+    "title": "Biology Seminar Requirement",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "BIOLTEC",
+    "title": "Math-Bio Technical Elective",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -5347,8 +5425,8 @@
   },
   {
     "code": "CHEM051",
-    "title": "Lab, General Chemistry (Accel)",
-    "campus": "po",
+    "title": "Physical Chem: Thermody/Kinetics",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -5503,8 +5581,8 @@
   },
   {
     "code": "CHEM112",
-    "title": "Analysis Scientific Literature",
-    "campus": "po",
+    "title": "Instrumental Analysis Laboratory",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -5515,7 +5593,7 @@
   },
   {
     "code": "CHEM115",
-    "title": "Lab, Biochemistry",
+    "title": "Biochemistry w/Laboratory",
     "campus": "po",
     "credits": 3.0
   },
@@ -5575,8 +5653,8 @@
   },
   {
     "code": "CHEM122",
-    "title": "Principles of Physical Chemistry",
-    "campus": "sc",
+    "title": "Materials Chemistry Laboratory",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -5641,7 +5719,7 @@
   },
   {
     "code": "CHEM147",
-    "title": "Lab, Inorganic Chemistry",
+    "title": "Inorganic Chemistry",
     "campus": "po",
     "credits": 3.0
   },
@@ -5689,13 +5767,13 @@
   },
   {
     "code": "CHEM161",
-    "title": "Lab, Advanced Analytical",
-    "campus": "po",
+    "title": "AdvPhysChem:Classicl/Stat Thermo",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "CHEM162",
-    "title": "Lab, Adv Physical Chem",
+    "title": "Physical Chemistry Laboratory",
     "campus": "po",
     "credits": 3.0
   },
@@ -5707,8 +5785,8 @@
   },
   {
     "code": "CHEM164",
-    "title": "Computational Chemistry",
-    "campus": "po",
+    "title": "Electronic Structure Theory",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -5773,14 +5851,14 @@
   },
   {
     "code": "CHEM171",
-    "title": "Organic Synthesis",
-    "campus": "po",
+    "title": "Adv Org Chem: Organic Synthesis",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "CHEM172",
     "title": "NMR Spectroscopy",
-    "campus": "po",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -5804,7 +5882,7 @@
   {
     "code": "CHEM175",
     "title": "Intro to Medicinal Chemistry",
-    "campus": "po",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -5821,8 +5899,8 @@
   },
   {
     "code": "CHEM180",
-    "title": "Advanced Biochemistry",
-    "campus": "po",
+    "title": "Applied Molecular Evolution",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -5899,8 +5977,8 @@
   },
   {
     "code": "CHEM191",
-    "title": "Senior Literature Thesis",
-    "campus": "po",
+    "title": "One-Semester Thesis in Chemistry",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -5971,8 +6049,8 @@
   },
   {
     "code": "CHEM194",
-    "title": "Senior Experimental Thesis",
-    "campus": "po",
+    "title": "Chemistry of Modern Materials",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -5983,14 +6061,14 @@
   },
   {
     "code": "CHEM198",
-    "title": "Independent Internship",
-    "campus": "sc",
+    "title": "Special Readings in Chemistry",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "CHEM199",
-    "title": "Independent Study in Chemistry",
-    "campus": "sc",
+    "title": "Chemistry Seminar",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -6018,15 +6096,21 @@
     "credits": 3.0
   },
   {
+    "code": "CHEMELECTHM",
+    "title": "Chemistry Major Elective",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "CHIN001A",
-    "title": "Elementary Chinese",
-    "campus": "po",
+    "title": "Elementary Chinese 1",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "CHIN001B",
-    "title": "Elementary Chinese",
-    "campus": "po",
+    "title": "Elementary Chinese 2",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -6169,7 +6253,7 @@
   },
   {
     "code": "CHLT060",
-    "title": "Women in the The Third World",
+    "title": "Women in the Third World",
     "campus": "pz",
     "credits": 3.0
   },
@@ -6277,7 +6361,7 @@
   },
   {
     "code": "CHLT153",
-    "title": "Rural and Urban Social Movements",
+    "title": "Rural & Urban Social Movements",
     "campus": "pz",
     "credits": 3.0
   },
@@ -6373,7 +6457,7 @@
   },
   {
     "code": "CHST015",
-    "title": "Intro to Chicanx Latinx Studies",
+    "title": "Intro to Chicana/o Latina/o St",
     "campus": "sc",
     "credits": 3.0
   },
@@ -6391,7 +6475,7 @@
   },
   {
     "code": "CHST064",
-    "title": "Chicanx Music Experience",
+    "title": "Chicano/a Music Experience",
     "campus": "sc",
     "credits": 3.0
   },
@@ -6403,7 +6487,7 @@
   },
   {
     "code": "CHST067",
-    "title": "Contemp Chicanx Art/Antecedents",
+    "title": "Contemp Chicano Art/Antecedents",
     "campus": "sc",
     "credits": 3.0
   },
@@ -6415,7 +6499,7 @@
   },
   {
     "code": "CHST077",
-    "title": "Chicana-Latina,Gndr,Pop Culture",
+    "title": "Chicana/Latina,Gndr,Pop Culture",
     "campus": "sc",
     "credits": 3.0
   },
@@ -6445,25 +6529,25 @@
   },
   {
     "code": "CHST125",
-    "title": "Latinxs in the 20th Century",
+    "title": "Latinas/os in the 20th Century",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "CHST126A",
-    "title": "Chicanx Movement Literature",
+    "title": "Chicano/a Movement Literature",
     "campus": "sc",
     "credits": 3.0
   },
   {
     "code": "CHST126B",
-    "title": "Contemporary Chicanx Literature",
+    "title": "Contemporary Chicana/o Lit",
     "campus": "sc",
     "credits": 3.0
   },
   {
     "code": "CHST128",
-    "title": "Latinx Citizenship",
+    "title": "The Politics of Citizenship",
     "campus": "po",
     "credits": 3.0
   },
@@ -6475,13 +6559,13 @@
   },
   {
     "code": "CHST132",
-    "title": "Immigrant Youth Activism (CP)",
+    "title": "Immigrant Youth Activism",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "CHST136",
-    "title": "Chicanx/Latinx Social Movements",
+    "title": "Chicano/a Latino/a Politics",
     "campus": "po",
     "credits": 3.0
   },
@@ -6493,13 +6577,13 @@
   },
   {
     "code": "CHST184D",
-    "title": "Chicanx Short Fiction",
+    "title": "Chicana/o Short Fiction",
     "campus": "sc",
     "credits": 3.0
   },
   {
     "code": "CHST185A",
-    "title": "Decolonial Love US Latinx Lit",
+    "title": "Decolonial Love US Latina/o Lit",
     "campus": "sc",
     "credits": 3.0
   },
@@ -6590,31 +6674,31 @@
   {
     "code": "CLAS008A",
     "title": "Introductory Latin",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "CLAS008B",
     "title": "Introductory Latin",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "CLAS010",
-    "title": "Epic Heroes & Form in Pop Cult",
-    "campus": "sc",
+    "title": "The Epic Tradition",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "CLAS012",
-    "title": "Greek Tragedy in Modern World",
-    "campus": "sc",
+    "title": "Greek Tragedy",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "CLAS014",
-    "title": "Ancient Comedy",
-    "campus": "sc",
+    "title": "The Ancient Comic Tradition",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -6631,20 +6715,20 @@
   },
   {
     "code": "CLAS018",
-    "title": "The Ancient Novel and Romance",
-    "campus": "sc",
+    "title": "Love and Identity",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "CLAS019",
-    "title": "Classical Myth in Film",
+    "title": "The Ancient World in Film",
     "campus": "sc",
     "credits": 3.0
   },
   {
     "code": "CLAS020",
-    "title": "Fantastic Archaeology",
-    "campus": "pz",
+    "title": "The Trojan War",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -6655,20 +6739,20 @@
   },
   {
     "code": "CLAS032",
-    "title": "Introductory/Intermediate Latin",
-    "campus": "pz",
+    "title": "Introductory Latin Accelerated",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "CLAS051A",
     "title": "Introductory Classical Greek",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "CLAS051B",
     "title": "Introductory Classical Greek",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -6722,25 +6806,25 @@
   {
     "code": "CLAS100",
     "title": "Intermediate Latin",
-    "campus": "pz",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "CLAS101A",
-    "title": "Intermediate Classical Greek",
-    "campus": "sc",
+    "title": "Intermediate Greek",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "CLAS101B",
-    "title": "Intermediate Classical Greek",
-    "campus": "sc",
+    "title": "Intermediate Greek",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "CLAS103",
     "title": "Intermediate Latin: Medieval",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -6758,31 +6842,31 @@
   {
     "code": "CLAS110",
     "title": "Cicero",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "CLAS112",
     "title": "Vergil",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "CLAS113",
     "title": "History of Sexuality: Clas World",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "CLAS114",
     "title": "Female & Male in Ancient Greece",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "CLAS115",
-    "title": "Antiquity and the East",
-    "campus": "sc",
+    "title": "Politics of Persuasion in Athens",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -6793,7 +6877,7 @@
   },
   {
     "code": "CLAS116A",
-    "title": "Out of The Cave",
+    "title": "Philosophy of Education",
     "campus": "po",
     "credits": 3.0
   },
@@ -6818,7 +6902,7 @@
   {
     "code": "CLAS130",
     "title": "Roman Decadence",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -6841,14 +6925,14 @@
   },
   {
     "code": "CLAS145",
-    "title": "Ancient Political Thought",
-    "campus": "sc",
+    "title": "Archaeology Seminar",
+    "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "CLAS150",
-    "title": "Spec Top in Ancient Studies",
-    "campus": "sc",
+    "title": "Special Topics Seminar",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -6896,13 +6980,13 @@
   {
     "code": "CLAS181A",
     "title": "Advanced Latin Readings",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "CLAS181B",
     "title": "Advanced Latin Readings",
-    "campus": "pz",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -6914,19 +6998,19 @@
   {
     "code": "CLAS182B",
     "title": "Advanced Greek Readings",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "CLAS190",
-    "title": "Sr Seminar: Ancient St/Classics",
-    "campus": "sc",
+    "title": "Senior Seminar",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "CLAS191",
-    "title": "Sr Thesis: Ancient St/Classics",
-    "campus": "sc",
+    "title": "Senior Thesis in Classics",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -6938,7 +7022,7 @@
   {
     "code": "CLAS193",
     "title": "Senior Seminar: Classics",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -6969,6 +7053,12 @@
     "code": "CLAS199RAPO",
     "title": "Classics: Research Assistantship",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "CLINICDBLHM",
+    "title": "Clinic/Thesis Double Count",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -7086,6 +7176,12 @@
     "credits": 3.0
   },
   {
+    "code": "CMC",
+    "title": "CMC Level-II Econ Elective",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "CMC199",
     "title": "Off Campus Study",
     "campus": "cmc",
@@ -7095,6 +7191,12 @@
     "code": "COGS011",
     "title": "Intro to Cognitive Science",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "CONCELECT",
+    "title": "Concentration Elective",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -7171,13 +7273,13 @@
   },
   {
     "code": "CREA018",
-    "title": "History of the Creative Process",
+    "title": "Introduction to Creative Studies",
     "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "CREA025",
-    "title": "World in a Nutshell:Short Storie",
+    "title": "World in a Nutshell",
     "campus": "pz",
     "credits": 3.0
   },
@@ -7243,7 +7345,7 @@
   },
   {
     "code": "CREA102",
-    "title": "Museums and Material Culture",
+    "title": "Art, Aesthetic & Resistance",
     "campus": "pz",
     "credits": 3.0
   },
@@ -7370,7 +7472,7 @@
   {
     "code": "CSCI005",
     "title": "Introduction to Computer Science",
-    "campus": "pz",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -7399,7 +7501,7 @@
   },
   {
     "code": "CSCI030",
-    "title": "Lab, Computation and Cognition",
+    "title": "Computation & Cognition w/Lab",
     "campus": "po",
     "credits": 3.0
   },
@@ -7489,7 +7591,7 @@
   },
   {
     "code": "CSCI051G",
-    "title": "Intro to CS in Grace w/Lab",
+    "title": "Introduction to CS in Grace",
     "campus": "po",
     "credits": 3.0
   },
@@ -7526,7 +7628,7 @@
   {
     "code": "CSCI052",
     "title": "Fundamentals of Computer Science",
-    "campus": "po",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -7537,8 +7639,8 @@
   },
   {
     "code": "CSCI055",
-    "title": "Discrete Mathematics",
-    "campus": "po",
+    "title": "Discrete Structures",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -7555,8 +7657,8 @@
   },
   {
     "code": "CSCI062",
-    "title": "Data Structures/Adv Program Lab",
-    "campus": "po",
+    "title": "Data Structures Adv Programming",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -7585,8 +7687,8 @@
   },
   {
     "code": "CSCI081",
-    "title": "Computability & Logic",
-    "campus": "po",
+    "title": "Computability and Logic",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -7603,8 +7705,8 @@
   },
   {
     "code": "CSCI105",
-    "title": "Computer Systems, Lab",
-    "campus": "po",
+    "title": "Computer Systems",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -7633,8 +7735,8 @@
   },
   {
     "code": "CSCI124",
-    "title": "User Interfaces and Experience",
-    "campus": "po",
+    "title": "Interaction Design",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -7658,7 +7760,7 @@
   {
     "code": "CSCI131",
     "title": "Programming Languages",
-    "campus": "po",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -7669,14 +7771,14 @@
   },
   {
     "code": "CSCI133",
-    "title": "Database Systems",
-    "campus": "po",
+    "title": "Databases",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "CSCI134",
-    "title": "Operating Systems Principles",
-    "campus": "po",
+    "title": "Operating Systems",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -7687,8 +7789,8 @@
   },
   {
     "code": "CSCI136",
-    "title": "Computer Architecture",
-    "campus": "po",
+    "title": "Advanced Computer Architecture",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -7700,7 +7802,7 @@
   {
     "code": "CSCI140",
     "title": "Algorithms",
-    "campus": "po",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -7712,7 +7814,7 @@
   {
     "code": "CSCI143",
     "title": "Applied Algorithms",
-    "campus": "po",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -7736,7 +7838,7 @@
   {
     "code": "CSCI151",
     "title": "Artificial Intelligence",
-    "campus": "po",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -7760,7 +7862,7 @@
   {
     "code": "CSCI155",
     "title": "Computer Graphics",
-    "campus": "pz",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -7778,19 +7880,19 @@
   {
     "code": "CSCI158",
     "title": "Machine Learning",
-    "campus": "po",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "CSCI159",
     "title": "Natural Language Processing",
-    "campus": "po",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "CSCI160",
-    "title": "Applied Machine Learning",
-    "campus": "pz",
+    "title": "Information Retrieval",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -7801,8 +7903,8 @@
   },
   {
     "code": "CSCI181A",
-    "title": "Seminar on Information Security",
-    "campus": "po",
+    "title": "Topics in Networks",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -7819,8 +7921,8 @@
   },
   {
     "code": "CSCI181D",
-    "title": "Architecture Aware Algorithms",
-    "campus": "po",
+    "title": "Computational Complexity",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -7879,38 +7981,38 @@
   },
   {
     "code": "CSCI181N",
-    "title": "Advanced Functional Programming",
-    "campus": "po",
+    "title": "Computer Security",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "CSCI181O",
-    "title": "Computational Semantics",
-    "campus": "po",
+    "title": "Human Robot Interaction",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "CSCI181P",
-    "title": "Image Processing",
-    "campus": "po",
+    "title": "Machine Learning, Info, & Search",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "CSCI181Q",
-    "title": "Graph Algorithm and Application",
-    "campus": "po",
+    "title": "The Science of Debugging",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "CSCI181R",
-    "title": "Network Analysis and Mining",
-    "campus": "po",
+    "title": "Human Data Science Ethics",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "CSCI181S",
-    "title": "System Security",
-    "campus": "po",
+    "title": "Computational Creativity Seminar",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -7921,8 +8023,8 @@
   },
   {
     "code": "CSCI181U",
-    "title": "Building an Internet of Things",
-    "campus": "po",
+    "title": "Applied Logic/AutomatedReasoning",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -8023,8 +8125,8 @@
   },
   {
     "code": "CSCI191",
-    "title": "Senior Thesis: Computer Science",
-    "campus": "sc",
+    "title": "Sr Research/Thesis Computer Sci",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -8070,6 +8172,12 @@
     "credits": 3.0
   },
   {
+    "code": "CSCIELECTHM",
+    "title": "CSCI Major/Minor Elective",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "CSMT181",
     "title": "Special Topics in Comp Sci/Math",
     "campus": "hmc",
@@ -8107,7 +8215,7 @@
   },
   {
     "code": "DANC013",
-    "title": "Beginning Tap Dance",
+    "title": "Intermediate Tap",
     "campus": "po",
     "credits": 3.0
   },
@@ -8156,7 +8264,7 @@
   {
     "code": "DANC077A",
     "title": "Modern Dance II",
-    "campus": "sc",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -8227,7 +8335,7 @@
   },
   {
     "code": "DANC103",
-    "title": "Language of the Body",
+    "title": "Laban Movement Analysis",
     "campus": "sc",
     "credits": 3.0
   },
@@ -8293,25 +8401,25 @@
   },
   {
     "code": "DANC112A",
-    "title": "Jazz Dance II",
+    "title": "Jazz Dance",
     "campus": "sc",
     "credits": 3.0
   },
   {
     "code": "DANC112B",
-    "title": "Jazz Dance II",
+    "title": "Jazz Dance",
     "campus": "sc",
     "credits": 3.0
   },
   {
     "code": "DANC114A",
-    "title": "Yoga: Evolving Practices",
+    "title": "Somatics of Yoga",
     "campus": "sc",
     "credits": 3.0
   },
   {
     "code": "DANC114B",
-    "title": "Yoga: Evolving Practices",
+    "title": "Somatics of Yoga",
     "campus": "sc",
     "credits": 3.0
   },
@@ -8353,8 +8461,8 @@
   },
   {
     "code": "DANC130",
-    "title": "The Body and World Performance",
-    "campus": "sc",
+    "title": "Language of the Body",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -8371,14 +8479,14 @@
   },
   {
     "code": "DANC134",
-    "title": "Movement as Culture",
-    "campus": "sc",
+    "title": "Middle East Art and Aesthetics",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "DANC135",
-    "title": "Introduction West African Dance",
-    "campus": "sc",
+    "title": "Traditions of World Dance",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -8389,14 +8497,14 @@
   },
   {
     "code": "DANC136B",
-    "title": "West African Dance II",
+    "title": "West Afica Dance II",
     "campus": "sc",
     "credits": 3.0
   },
   {
     "code": "DANC137",
-    "title": "Latin American Dance Practices",
-    "campus": "sc",
+    "title": "Performing Art: Sexuality/Gender",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -8413,19 +8521,19 @@
   },
   {
     "code": "DANC140",
-    "title": "Music for Dancers",
-    "campus": "sc",
+    "title": "Beg Creative Movmnt Exploration",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "DANC141",
-    "title": "Composition: Tools, Structures",
+    "title": "Composition 2:Choreography Lab",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "DANC142",
-    "title": "Improvisation Techniques",
+    "title": "Improvisation",
     "campus": "po",
     "credits": 3.0
   },
@@ -8509,8 +8617,8 @@
   },
   {
     "code": "DANC160",
-    "title": "Dance Composition II",
-    "campus": "sc",
+    "title": "Anatomy and Kinesiology",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -8641,8 +8749,8 @@
   },
   {
     "code": "DANC198",
-    "title": "Independent Internship",
-    "campus": "sc",
+    "title": "Summer Reading & Research",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -8664,6 +8772,12 @@
     "credits": 3.0
   },
   {
+    "code": "DBLCORE",
+    "title": "Double-Counted Core Course",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "DGHM150",
     "title": "Digital Humanities Studio",
     "campus": "cmc",
@@ -8676,15 +8790,27 @@
     "credits": 3.0
   },
   {
+    "code": "DMEX",
+    "title": "F/T Enrollment - Domestic Exchng",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "DS180",
     "title": "Adv Projects in Data Science",
     "campus": "cmc",
     "credits": 3.0
   },
   {
+    "code": "EA",
+    "title": "Envir Analysis:Directed Readings",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "EA010",
     "title": "Intro to Environmental Analysis",
-    "campus": "sc",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -8701,7 +8827,7 @@
   },
   {
     "code": "EA030",
-    "title": "Lab, Science and the Environment",
+    "title": "Science and the Environment",
     "campus": "po",
     "credits": 3.0
   },
@@ -8809,14 +8935,14 @@
   },
   {
     "code": "EA085",
-    "title": "Food, Land & The Environment",
+    "title": "Food, Land & the Environment",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "EA086",
     "title": "Environmental Justice",
-    "campus": "sc",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -8827,13 +8953,13 @@
   },
   {
     "code": "EA090",
-    "title": "Protecting the Sacred",
+    "title": "Environmental Change in E. Asia",
     "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "EA091",
-    "title": "Calif. Env. Law,Policy & Politcs",
+    "title": "Air Pollution: History & Policy",
     "campus": "pz",
     "credits": 3.0
   },
@@ -8869,7 +8995,7 @@
   },
   {
     "code": "EA098",
-    "title": "Urban Environments",
+    "title": "Urban Ecology",
     "campus": "pz",
     "credits": 3.0
   },
@@ -8887,19 +9013,19 @@
   },
   {
     "code": "EA100L",
-    "title": "Global Climate Change w/Lab",
+    "title": "Global Climate Change",
     "campus": "sc",
     "credits": 3.0
   },
   {
     "code": "EA101",
-    "title": "GIS in Env Analysis, Lab",
+    "title": "GIS in Environmental Analysis",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "EA102",
-    "title": "Adv GIS",
+    "title": "Advanced GIS in EA",
     "campus": "po",
     "credits": 3.0
   },
@@ -8911,14 +9037,14 @@
   },
   {
     "code": "EA103L",
-    "title": "Soils and Society w/Lab",
+    "title": "Principles of Soil Science",
     "campus": "sc",
     "credits": 3.0
   },
   {
     "code": "EA104",
-    "title": "Doing Natural History",
-    "campus": "pz",
+    "title": "Oceanography",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -8941,8 +9067,8 @@
   },
   {
     "code": "EA110",
-    "title": "Experiencing Sustainability",
-    "campus": "sc",
+    "title": "Agriculture & Enviro Protection",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -8977,7 +9103,7 @@
   },
   {
     "code": "EA131",
-    "title": "Democratizing Community Planning",
+    "title": "Restoring Nature",
     "campus": "pz",
     "credits": 3.0
   },
@@ -9001,7 +9127,7 @@
   },
   {
     "code": "EA135",
-    "title": "NatureWorks",
+    "title": "NatureWorks: Aesthetics &",
     "campus": "pz",
     "credits": 3.0
   },
@@ -9091,7 +9217,7 @@
   },
   {
     "code": "EA162",
-    "title": "Gender, Environment & Developmnt",
+    "title": "Gender,Environment & Development",
     "campus": "pz",
     "credits": 3.0
   },
@@ -9152,7 +9278,7 @@
   {
     "code": "EA180",
     "title": "Green Urbanism",
-    "campus": "pz",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -9217,8 +9343,8 @@
   },
   {
     "code": "EA191",
-    "title": "Thesis in Environmental Analysis",
-    "campus": "po",
+    "title": "EA Science 1-semester Sr Thesis",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -9289,14 +9415,14 @@
   },
   {
     "code": "ECON051",
-    "title": "Principles of Macroeconomics",
-    "campus": "sc",
+    "title": "Principles: Macroeconomics",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ECON052",
-    "title": "Principles of Microeconomics",
-    "campus": "sc",
+    "title": "Principles: Microeconomics",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -9355,8 +9481,8 @@
   },
   {
     "code": "ECON070",
-    "title": "Issues in Environmental Econ",
-    "campus": "sc",
+    "title": "Principles of Financial Econ",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -9373,8 +9499,8 @@
   },
   {
     "code": "ECON086",
-    "title": "Financial Accounting",
-    "campus": "sc",
+    "title": "Accounting for Decision Making",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -9391,7 +9517,7 @@
   },
   {
     "code": "ECON097",
-    "title": "Public Policy Analysis",
+    "title": "Public Policy Anaylsis",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -9409,14 +9535,14 @@
   },
   {
     "code": "ECON101",
-    "title": "Intermed Microeconomic Theory",
-    "campus": "sc",
+    "title": "Intermediate Microeconomics",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON102",
-    "title": "Intermed Macroeconomic Theory",
-    "campus": "sc",
+    "title": "Intermediate Macroeconomics",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -9427,8 +9553,8 @@
   },
   {
     "code": "ECON104",
-    "title": "Macroeconomic Theory",
-    "campus": "pz",
+    "title": "Financial Economics",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -9439,8 +9565,8 @@
   },
   {
     "code": "ECON107",
-    "title": "Applied Econometrics",
-    "campus": "po",
+    "title": "Neuroeconomics",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -9475,13 +9601,13 @@
   },
   {
     "code": "ECON113",
-    "title": "International Economic Relations",
-    "campus": "po",
+    "title": "European Economic History",
+    "campus": "sc",
     "credits": 3.0
   },
   {
     "code": "ECON114",
-    "title": "Development of American Markets",
+    "title": "Development of American Economy",
     "campus": "sc",
     "credits": 3.0
   },
@@ -9493,14 +9619,14 @@
   },
   {
     "code": "ECON115",
-    "title": "Labor Economics",
-    "campus": "pz",
+    "title": "Economics of Immigration",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ECON116",
-    "title": "Race in the U.S. Economy",
-    "campus": "sc",
+    "title": "Race in the US Economy",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -9511,8 +9637,8 @@
   },
   {
     "code": "ECON118",
-    "title": "Economics of Sports",
-    "campus": "po",
+    "title": "Processes of Env Policymaking",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -9523,8 +9649,8 @@
   },
   {
     "code": "ECON120",
-    "title": "Economics of Crime",
-    "campus": "po",
+    "title": "Statistics",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -9535,8 +9661,8 @@
   },
   {
     "code": "ECON121",
-    "title": "Economics of Immigration",
-    "campus": "pz",
+    "title": "Economics of Gender & the Family",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -9547,44 +9673,44 @@
   },
   {
     "code": "ECON123",
-    "title": "International Economics",
-    "campus": "po",
+    "title": "Quantitative Data Analysis",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON124",
-    "title": "Emerging Asia",
-    "campus": "pz",
+    "title": "Wat. Res. Econ. and Mgmt",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ECON125",
-    "title": "Econometrics",
-    "campus": "sc",
+    "title": "Econometrics I",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON126",
-    "title": "Economic Development",
-    "campus": "po",
+    "title": "Microeconometrics",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON127",
-    "title": "China & Japan: Economy & Society",
-    "campus": "pz",
+    "title": "Special Topics in Econometrics",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON128",
-    "title": "Energy Economics, & Policy",
-    "campus": "po",
+    "title": "Data Science",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON129",
-    "title": "Health Economics",
-    "campus": "po",
+    "title": "Game Theory",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -9607,8 +9733,8 @@
   },
   {
     "code": "ECON134",
-    "title": "Money and Banking",
-    "campus": "pz",
+    "title": "Corporate Finance",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -9625,8 +9751,8 @@
   },
   {
     "code": "ECON135",
-    "title": "Monetary and Financial Economics",
-    "campus": "sc",
+    "title": "International Economics",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -9637,86 +9763,86 @@
   },
   {
     "code": "ECON137",
-    "title": "Healthcare Economics",
-    "campus": "sc",
+    "title": "Special Topics in Corp Finance",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON138",
-    "title": "Financial Economics",
-    "campus": "pz",
+    "title": "Current Issues Money & Finance",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON139",
-    "title": "Security Valu & Portfolio Analy",
-    "campus": "sc",
+    "title": "Topics: Investments & Valuation",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON140",
-    "title": "International Economics",
-    "campus": "sc",
+    "title": "Economics of Gender,Work,Family",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "ECON141",
-    "title": "The Chinese Economy",
-    "campus": "pz",
+    "title": "International Economics",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON142",
-    "title": "Emerging Econ of Europe & Asia",
-    "campus": "sc",
+    "title": "Development Economics",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "ECON143",
-    "title": "US Foreign Policy & 3rd World",
-    "campus": "pz",
+    "title": "The Chinese Economy",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON144",
-    "title": "Economic Development",
-    "campus": "sc",
+    "title": "Economic Anthropology",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "ECON145",
-    "title": "International Trade",
-    "campus": "pz",
+    "title": "International Money & Finance",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON146",
-    "title": "International Money & Finance",
-    "campus": "pz",
+    "title": "International Economic Relations",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON147",
-    "title": "International Money and Finance",
-    "campus": "pz",
+    "title": "Int'l Trade Theory & Policy",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON148",
-    "title": "Trade & Development",
-    "campus": "pz",
+    "title": "Regional Economic Integration",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON149",
-    "title": "Asian Economic Development",
-    "campus": "pz",
+    "title": "Int'l Acct, Tax & Transfer Price",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON150",
-    "title": "Industrial Organization",
-    "campus": "po",
+    "title": "Political Economy of Higher Educ",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -9727,44 +9853,44 @@
   },
   {
     "code": "ECON151",
-    "title": "Labor Economics",
-    "campus": "po",
+    "title": "Strategic Cost Management",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON152",
-    "title": "Money, Banking & Fin Markets",
-    "campus": "po",
+    "title": "Tax Planning",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON153",
-    "title": "Urban & Regional Economics",
-    "campus": "po",
+    "title": "Intermediate Macroeconomics",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "ECON154",
-    "title": "Game Theory for Economists",
-    "campus": "po",
+    "title": "Intermediate Microeconomics",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "ECON155",
-    "title": "History of Economic Thought",
-    "campus": "pz",
+    "title": "Intermediate Accounting II",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON156",
-    "title": "Security Valutn & Portfolio Thry",
-    "campus": "po",
+    "title": "Accounting Ethics",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON157",
-    "title": "Corporate Finance",
-    "campus": "po",
+    "title": "Advanced Management & Control",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -9775,56 +9901,56 @@
   },
   {
     "code": "ECON159",
-    "title": "Economics of the Public Sector",
-    "campus": "po",
+    "title": "Accounting Theory and Research",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON160",
-    "title": "Political Economy of Law",
-    "campus": "sc",
+    "title": "Info Tech & Acct System Design",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON161",
-    "title": "Advanced Macroeconomic Analysis",
-    "campus": "po",
+    "title": "Sports Economics",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON162",
-    "title": "Advanced Microeconomic Analysis",
-    "campus": "po",
+    "title": "Internet Economics & Strategy",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON163",
-    "title": "Econ of Poverty & Discrimination",
-    "campus": "pz",
+    "title": "The Economics of Health Care",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON164",
-    "title": "Technology and Growth",
-    "campus": "po",
+    "title": "Economics of Strategy",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON165",
-    "title": "Bus Strategy & Industrial Orgnz",
-    "campus": "sc",
+    "title": "Industrial Organization",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON166",
-    "title": "Poli Econ of Agrarian Change",
-    "campus": "pz",
+    "title": "Empirical Indst Org w/ Practicum",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON167",
-    "title": "History of Economic Thought",
-    "campus": "pz",
+    "title": "Law and Economics",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -9841,14 +9967,14 @@
   },
   {
     "code": "ECON170",
-    "title": "Environmental Economics",
-    "campus": "sc",
+    "title": "Urban and Regional Economics",
+    "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "ECON171",
-    "title": "Econ of Environmental Policy",
-    "campus": "sc",
+    "title": "Environmental Economics",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -9859,26 +9985,26 @@
   },
   {
     "code": "ECON173",
-    "title": "Economics of Innovation",
-    "campus": "pz",
+    "title": "Economic Development",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON174",
-    "title": "Health Economics",
-    "campus": "pz",
+    "title": "Economics of Entrepreneurship",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON175",
-    "title": "Labor and Personnel Economics",
-    "campus": "sc",
+    "title": "Labor Economics",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON176",
-    "title": "Economics of the Public Sector",
-    "campus": "pz",
+    "title": "Practicum in Real Property Econ",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -9919,8 +10045,8 @@
   },
   {
     "code": "ECON180",
-    "title": "Modern Political Economy",
-    "campus": "sc",
+    "title": "Seminar in Research Methods",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -9949,8 +10075,8 @@
   },
   {
     "code": "ECON184",
-    "title": "Behavioral Finance",
-    "campus": "sc",
+    "title": "Behavioral Economics",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -9961,14 +10087,14 @@
   },
   {
     "code": "ECON186",
-    "title": "Neuroeconomics",
-    "campus": "pz",
+    "title": "Public Economics & Welfare",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON187",
-    "title": "Public Finance",
-    "campus": "sc",
+    "title": "Poverty, Inequality, Discrimnatn",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -9985,14 +10111,14 @@
   },
   {
     "code": "ECON190",
-    "title": "Senior Seminar in Economics",
-    "campus": "po",
+    "title": "Ethics and Management",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON191",
-    "title": "Senior Thesis in Economics",
-    "campus": "sc",
+    "title": "Business Law",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -10009,8 +10135,8 @@
   },
   {
     "code": "ECON193",
-    "title": "Managerial Economics",
-    "campus": "sc",
+    "title": "Entrep Finance & Venture Cap",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -10081,14 +10207,14 @@
   },
   {
     "code": "ECON198",
-    "title": "Independent Internship",
-    "campus": "sc",
+    "title": "Economics of Innovation",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ECON199",
-    "title": "Independent Study in Economics",
-    "campus": "sc",
+    "title": "Independent Study & Research",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -10141,7 +10267,7 @@
   },
   {
     "code": "ECON313",
-    "title": "Microeconomic Analysis",
+    "title": "Microeconomic Analysis I",
     "campus": "cgu",
     "credits": 3.0
   },
@@ -10153,7 +10279,7 @@
   },
   {
     "code": "ECON317",
-    "title": "Game Theory & Asymmetric Info",
+    "title": "Advanced Microeconomics II",
     "campus": "cgu",
     "credits": 3.0
   },
@@ -10351,7 +10477,7 @@
   },
   {
     "code": "EDUC407",
-    "title": "Educational Policy",
+    "title": "Public Policy & America's School",
     "campus": "cgu",
     "credits": 3.0
   },
@@ -10543,7 +10669,7 @@
   },
   {
     "code": "ENGL003",
-    "title": "B(L)ack to Nature: Bird Watching",
+    "title": "Transatlantic Blk/Asian Film/Lit",
     "campus": "pz",
     "credits": 3.0
   },
@@ -10555,7 +10681,7 @@
   },
   {
     "code": "ENGL009",
-    "title": "Black Feminist Community Lrning",
+    "title": "Comnty Poetry:Black Feminst rEVO",
     "campus": "pz",
     "credits": 3.0
   },
@@ -10585,7 +10711,7 @@
   },
   {
     "code": "ENGL012",
-    "title": "Intro to African-American Lit",
+    "title": "Intro to Afr-Amer Lit after 1865",
     "campus": "pz",
     "credits": 3.0
   },
@@ -10705,7 +10831,7 @@
   },
   {
     "code": "ENGL031",
-    "title": "Introduction to Fiction Writing",
+    "title": "Intro Fiction & Nonfiction",
     "campus": "pz",
     "credits": 3.0
   },
@@ -10729,7 +10855,7 @@
   },
   {
     "code": "ENGL035",
-    "title": "Community Literary Practices",
+    "title": "Women and Fiction",
     "campus": "pz",
     "credits": 3.0
   },
@@ -10777,14 +10903,14 @@
   },
   {
     "code": "ENGL050",
-    "title": "Irish Literary Revival",
-    "campus": "pz",
+    "title": "Modern British & Irish Fiction",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ENGL051",
-    "title": "Literature of the Supernatural",
-    "campus": "pz",
+    "title": "Modern American Fiction",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -10873,7 +10999,7 @@
   },
   {
     "code": "ENGL064D",
-    "title": "Screenwriting",
+    "title": "Creative Writ:Literary Non-Fict",
     "campus": "po",
     "credits": 3.0
   },
@@ -10885,7 +11011,7 @@
   },
   {
     "code": "ENGL065",
-    "title": "Alchemical Cartography",
+    "title": "Special Topics-Creative Writing",
     "campus": "po",
     "credits": 3.0
   },
@@ -10927,14 +11053,14 @@
   },
   {
     "code": "ENGL074",
-    "title": "US Sports Literature",
-    "campus": "pz",
+    "title": "British Novel, Behn to Austen",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ENGL075",
-    "title": "Contemp. Chicana/o Literature",
-    "campus": "pz",
+    "title": "British Novel II",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -11047,8 +11173,8 @@
   },
   {
     "code": "ENGL090",
-    "title": "Alienation & Exile in Mod World",
-    "campus": "pz",
+    "title": "Medieval and Renaissance Lit.",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -11059,26 +11185,26 @@
   },
   {
     "code": "ENGL091",
-    "title": "Cross Borders, Rites of Passage",
-    "campus": "pz",
+    "title": "Englightnmnt,Romantic,Victrn Lit",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ENGL092",
-    "title": "City as Character in Lit & Film",
-    "campus": "pz",
+    "title": "Anglo-Irish Literary Tradition",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ENGL093",
-    "title": "World Lit in an Oceanic Context",
-    "campus": "pz",
+    "title": "Rock & Roll Writing",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ENGL094",
-    "title": "Growing Up Postcolonial\"\"",
-    "campus": "pz",
+    "title": "Pre-Contact to Civil War US Lit",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -11101,14 +11227,14 @@
   },
   {
     "code": "ENGL100",
-    "title": "Modernity Globaliztn Urbanizatn",
-    "campus": "pz",
+    "title": "Lit/Cultures of US Imperialism",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ENGL101",
-    "title": "Readings in British Literature",
-    "campus": "sc",
+    "title": "Modern Cuban Literature and Film",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -11143,14 +11269,14 @@
   },
   {
     "code": "ENGL103",
-    "title": "Afro-Futurism Black Sci-Fi",
-    "campus": "pz",
+    "title": "Literature of the Enlightenment",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ENGL104",
-    "title": "Intro to Poetry & Poetics",
-    "campus": "sc",
+    "title": "Romantic Literature",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -11161,8 +11287,8 @@
   },
   {
     "code": "ENGL107",
-    "title": "Harlem & Sophiatown Renaissance",
-    "campus": "pz",
+    "title": "William Blake",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -11179,8 +11305,8 @@
   },
   {
     "code": "ENGL109",
-    "title": "Lit and Film of African Diaspora",
-    "campus": "pz",
+    "title": "Intro to Performance Studies",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -11191,20 +11317,20 @@
   },
   {
     "code": "ENGL111",
-    "title": "Shakespeare Comedies & Histories",
-    "campus": "sc",
+    "title": "Amer Masculinities:Novel 19-20C",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ENGL112",
-    "title": "Shakespeare:Tragedies & Romances",
-    "campus": "sc",
+    "title": "Early Modern Romance",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ENGL113",
-    "title": "Vampires in Literature  & Film",
-    "campus": "pz",
+    "title": "Race/Gendr/Pop Culture 1865-1917",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -11221,14 +11347,14 @@
   },
   {
     "code": "ENGL116",
-    "title": "Early Modern Outsiders",
-    "campus": "sc",
+    "title": "Excess: Lit/Phil/Psychoanalysis",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ENGL117",
-    "title": "Contemporary American Fiction",
-    "campus": "pz",
+    "title": "Poststructuralism",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -11245,8 +11371,8 @@
   },
   {
     "code": "ENGL120",
-    "title": "Eighteenth-Century British Lit",
-    "campus": "sc",
+    "title": "Studies in Drama: Greek Tragedy",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -11257,20 +11383,20 @@
   },
   {
     "code": "ENGL121",
-    "title": "The Satirical Imagination",
-    "campus": "sc",
+    "title": "Studies in Poetry",
+    "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "ENGL122",
-    "title": "Gothic Fiction",
-    "campus": "sc",
+    "title": "Healing Narratives",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ENGL123",
-    "title": "Romantic Literature",
-    "campus": "sc",
+    "title": "Holocaust in Literature & Film",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -11287,14 +11413,14 @@
   },
   {
     "code": "ENGL124",
-    "title": "The Bible and Homer",
-    "campus": "pz",
+    "title": "AfroFuturisms",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ENGL125",
-    "title": "Victorian Novel",
-    "campus": "sc",
+    "title": "Literary Theory",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -11317,7 +11443,7 @@
   },
   {
     "code": "ENGL126",
-    "title": "Activist Poetics",
+    "title": "World Lit as Literary History",
     "campus": "pz",
     "credits": 3.0
   },
@@ -11335,14 +11461,14 @@
   },
   {
     "code": "ENGL129",
-    "title": "Literature of the Fin de Siecle",
-    "campus": "sc",
+    "title": "Spaces of Cultural Resistance",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ENGL130",
-    "title": "Character and the Novel",
-    "campus": "sc",
+    "title": "Topics 20th C Afr Diaspora Lit",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -11371,8 +11497,8 @@
   },
   {
     "code": "ENGL131",
-    "title": "Modern British Novel",
-    "campus": "sc",
+    "title": "Advanced Fiction Workshop",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -11389,8 +11515,8 @@
   },
   {
     "code": "ENGL132",
-    "title": "Contemporary Speculative Fiction",
-    "campus": "po",
+    "title": "Black Queer Studies",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -11419,8 +11545,8 @@
   },
   {
     "code": "ENGL135",
-    "title": "Advncd Feminist Creative Writing",
-    "campus": "pz",
+    "title": "The American\" Century\"",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -11449,20 +11575,20 @@
   },
   {
     "code": "ENGL140",
-    "title": "Victorian Hunger",
-    "campus": "pz",
+    "title": "Literature of Incarceration",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ENGL141",
-    "title": "The Slave Narrative & the Novel",
-    "campus": "sc",
+    "title": "Shakespearean Drama",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ENGL142",
-    "title": "The Early American Novel",
-    "campus": "sc",
+    "title": "Shakespeare's Poetic Practices",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -11479,19 +11605,19 @@
   },
   {
     "code": "ENGL144",
-    "title": "Melville & Douglass",
-    "campus": "sc",
+    "title": "Psychoanalysis and Literature",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ENGL145",
-    "title": "American Women Writers",
-    "campus": "sc",
+    "title": "Gothic Tradition",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ENGL146",
-    "title": "Asian American Poetry",
+    "title": "Modernist Poetry",
     "campus": "po",
     "credits": 3.0
   },
@@ -11515,8 +11641,8 @@
   },
   {
     "code": "ENGL149",
-    "title": "British Detective Lit",
-    "campus": "pz",
+    "title": "Korea's IMF-Crisis Cinema",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -11527,44 +11653,44 @@
   },
   {
     "code": "ENGL151",
-    "title": "American Modernism",
-    "campus": "sc",
+    "title": "Topics in Medieval Lit & Culture",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ENGL152",
-    "title": "Nature in 19th C British Lit",
-    "campus": "pz",
+    "title": "Medieval Roots of Modern Theory",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ENGL153",
-    "title": "Performing Literature",
-    "campus": "pz",
+    "title": "Medieval Nonsense",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ENGL154",
-    "title": "Novel on Screen",
+    "title": "Latinas in the Garment Industry",
     "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "ENGL155",
-    "title": "Multi-Ethnic Lit of the US",
-    "campus": "sc",
+    "title": "Shakespeare:Tragedies & Romances",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ENGL156",
-    "title": "Legal Fictions",
-    "campus": "pz",
+    "title": "Milton and Visual Culture",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ENGL157",
-    "title": "James Baldwin",
-    "campus": "sc",
+    "title": "The Empire Builders",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -11575,8 +11701,8 @@
   },
   {
     "code": "ENGL159",
-    "title": "Ethics & Dread in Victorian Lit",
-    "campus": "pz",
+    "title": "Supernatural Century",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -11617,14 +11743,14 @@
   },
   {
     "code": "ENGL161",
-    "title": "Futures of Asian/America",
-    "campus": "sc",
+    "title": "James Joyce",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ENGL162",
-    "title": "Asian Amer Lit:Gender+Sexuality",
-    "campus": "sc",
+    "title": "Race/Ethnicity in C19 US Lit",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -11635,8 +11761,8 @@
   },
   {
     "code": "ENGL164",
-    "title": "Essay and Experiment",
-    "campus": "po",
+    "title": "Harlem Renaissance",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -11647,14 +11773,14 @@
   },
   {
     "code": "ENGL166",
-    "title": "Literature, Illness & Disability",
+    "title": "James Baldwin",
     "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "ENGL167",
-    "title": "20th C Jewish-American Literatur",
-    "campus": "sc",
+    "title": "Writing and Exile",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -11665,7 +11791,7 @@
   },
   {
     "code": "ENGL167B",
-    "title": "Contemporary Chicanx Literature",
+    "title": "Contemporary Chicana/o Lit",
     "campus": "sc",
     "credits": 3.0
   },
@@ -11677,14 +11803,14 @@
   },
   {
     "code": "ENGL167D",
-    "title": "Chicanx Short Fiction",
+    "title": "Chicana/o Short Fiction",
     "campus": "sc",
     "credits": 3.0
   },
   {
     "code": "ENGL168",
-    "title": "Contemporary American Poetry",
-    "campus": "sc",
+    "title": "Writing Machines",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -11695,8 +11821,8 @@
   },
   {
     "code": "ENGL170",
-    "title": "Feminist Literary Theory",
-    "campus": "sc",
+    "title": "Advanced Studies Seminar English",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -11743,7 +11869,7 @@
   },
   {
     "code": "ENGL170J",
-    "title": "The Works of Toni Morrison",
+    "title": "Spec Topics American Literature",
     "campus": "po",
     "credits": 3.0
   },
@@ -11827,8 +11953,8 @@
   },
   {
     "code": "ENGL173",
-    "title": "Human Rights & World Literature",
-    "campus": "sc",
+    "title": "Desire in Literature & Culture",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -11851,7 +11977,7 @@
   },
   {
     "code": "ENGL177",
-    "title": "Caribbean Lit & Postcol Theory",
+    "title": "The Memoir",
     "campus": "sc",
     "credits": 3.0
   },
@@ -11863,14 +11989,14 @@
   },
   {
     "code": "ENGL181",
-    "title": "Intro Marxist Literary Criticism",
-    "campus": "sc",
+    "title": "Romanticisms:Desire in Lit/Film",
+    "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "ENGL182",
-    "title": "Politics & Aesthetics",
-    "campus": "sc",
+    "title": "Community Stds in Latina/o Lit",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -11905,8 +12031,8 @@
   },
   {
     "code": "ENGL184",
-    "title": "Seminar: 19thC Western Realism",
-    "campus": "pz",
+    "title": "New Poetics",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -11923,8 +12049,8 @@
   },
   {
     "code": "ENGL184C",
-    "title": "Seminar in Chicana/o Literature",
-    "campus": "pz",
+    "title": "Contemp Chicana Lit Seminar",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -11959,13 +12085,13 @@
   },
   {
     "code": "ENGL186",
-    "title": "Post-Apartheid Novels",
-    "campus": "pz",
+    "title": "Human Rights & World Literature",
+    "campus": "sc",
     "credits": 3.0
   },
   {
     "code": "ENGL187",
-    "title": "Race/Gender in Postcolonial Lit",
+    "title": "Nuruddin Farah",
     "campus": "sc",
     "credits": 3.0
   },
@@ -11983,19 +12109,19 @@
   },
   {
     "code": "ENGL189",
-    "title": "Fifties Film:Pop Culture Society",
-    "campus": "sc",
+    "title": "Postmodernism",
+    "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "ENGL189A",
-    "title": "John Ashbery",
+    "title": "The Transcendentalists 1836-1861",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ENGL189B",
-    "title": "Introduction to Literary Theory",
+    "title": "Defining Genius of Shakespeare",
     "campus": "po",
     "credits": 3.0
   },
@@ -12031,14 +12157,14 @@
   },
   {
     "code": "ENGL190",
-    "title": "Intro to Creative Writing",
-    "campus": "sc",
+    "title": "Senior Exercise/Seminar Option",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "ENGL191",
-    "title": "Poetry Writing Workshop",
-    "campus": "sc",
+    "title": "Senior Thesis",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -12055,8 +12181,8 @@
   },
   {
     "code": "ENGL193",
-    "title": "Intro to Fiction Writing",
-    "campus": "sc",
+    "title": "Fictions of James Joyce",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -12079,8 +12205,8 @@
   },
   {
     "code": "ENGL195",
-    "title": "Women in Ancient Indian Lit",
-    "campus": "pz",
+    "title": "Criticism: Advanced Methods",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -12121,14 +12247,14 @@
   },
   {
     "code": "ENGL198",
-    "title": "Independent Internship",
-    "campus": "sc",
+    "title": "Senior & Junior Seminar",
+    "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "ENGL199",
-    "title": "Independent Study in English",
-    "campus": "sc",
+    "title": "Senior Thesis",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -12924,6 +13050,12 @@
     "credits": 3.0
   },
   {
+    "code": "ENGRELECTHM",
+    "title": "Engineering Major/Minor Elective",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "ENVS191",
     "title": "Senior Thesis: Environmental St",
     "campus": "sc",
@@ -12954,9 +13086,21 @@
     "credits": 3.0
   },
   {
+    "code": "EXCHANGE",
+    "title": "Exchange Program Swarthmore",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "EXT100",
     "title": "Study Abroad Program",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "F/L",
+    "title": "Foreign Language - FULFILLED",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -13146,6 +13290,12 @@
     "credits": 3.0
   },
   {
+    "code": "FORLANG",
+    "title": "Foreign Language Req Fulfilled",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "FR800",
     "title": "Formal Reasoning Educ Objective",
     "campus": "pz",
@@ -13154,25 +13304,25 @@
   {
     "code": "FREN001",
     "title": "Introductory French",
-    "campus": "sc",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "FREN001L",
     "title": "Intro French Conversation Class",
-    "campus": "sc",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "FREN002",
-    "title": "Continued Introductory French",
-    "campus": "sc",
+    "title": "Continuing Introductory French",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "FREN002L",
-    "title": "Cont Intro French Conv Class",
-    "campus": "sc",
+    "title": "Cont Intro French Conversation",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -13196,25 +13346,25 @@
   {
     "code": "FREN022",
     "title": "Intensive Introductory French",
-    "campus": "sc",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "FREN022L",
     "title": "Intensive Int French Conv Class",
-    "campus": "sc",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "FREN033",
     "title": "Intermediate French",
-    "campus": "sc",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "FREN033L",
     "title": "Int French Conversation Class",
-    "campus": "sc",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -13225,14 +13375,14 @@
   },
   {
     "code": "FREN044",
-    "title": "Advanced French",
-    "campus": "sc",
+    "title": "Advanced French: Lit & Civ",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "FREN044L",
     "title": "Adv French Conversation Class",
-    "campus": "sc",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -13255,7 +13405,7 @@
   },
   {
     "code": "FREN103",
-    "title": "Frenchness: May '68-2018",
+    "title": "Frenchness: May '68-2008",
     "campus": "po",
     "credits": 3.0
   },
@@ -13273,8 +13423,8 @@
   },
   {
     "code": "FREN106",
-    "title": "French Business World & Language",
-    "campus": "sc",
+    "title": "French Creative Writing",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -13285,7 +13435,7 @@
   },
   {
     "code": "FREN108",
-    "title": "Notre-Dame de Paris",
+    "title": "Language & Power in Franco World",
     "campus": "po",
     "credits": 3.0
   },
@@ -13297,8 +13447,8 @@
   },
   {
     "code": "FREN110",
-    "title": "Liberte, Egalite, Fraternite?",
-    "campus": "sc",
+    "title": "French Films",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -13315,8 +13465,8 @@
   },
   {
     "code": "FREN113",
-    "title": "Banned in France",
-    "campus": "sc",
+    "title": "The Rise & Decline of Modernism",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -13339,7 +13489,7 @@
   },
   {
     "code": "FREN117",
-    "title": "African Novel and Film",
+    "title": "Novel & Cinema in Africa & Carib",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -13381,13 +13531,13 @@
   },
   {
     "code": "FREN124",
-    "title": "Writings of Freedom & Desire",
-    "campus": "sc",
+    "title": "The Novelist & Society in France",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "FREN125",
-    "title": "The French Detective",
+    "title": "Introduction to French Poetry",
     "campus": "sc",
     "credits": 3.0
   },
@@ -13399,14 +13549,14 @@
   },
   {
     "code": "FREN127",
-    "title": "French Contemp Women Directors",
-    "campus": "sc",
+    "title": "Language & Power in the Fr World",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "FREN128",
-    "title": "Writing Memory",
-    "campus": "sc",
+    "title": "The Fantastic",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -13447,13 +13597,13 @@
   },
   {
     "code": "FREN135",
-    "title": "The Art of the Short Story",
+    "title": "L'Art de la Nouvelle",
     "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "FREN137",
-    "title": "The Algerian War",
+    "title": "Algerian War & Fr Intelligentsia",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -13519,7 +13669,7 @@
   },
   {
     "code": "FREN152",
-    "title": "Literature as Resistance",
+    "title": "Masters, Servants, & Slaves",
     "campus": "po",
     "credits": 3.0
   },
@@ -13573,13 +13723,13 @@
   },
   {
     "code": "FREN173",
-    "title": "Wit/Ridicule in the French Salon",
-    "campus": "sc",
+    "title": "Reading Bodies",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "FREN174",
-    "title": "Adultery in the Novel",
+    "title": "The Romantic Others",
     "campus": "po",
     "credits": 3.0
   },
@@ -13615,8 +13765,8 @@
   },
   {
     "code": "FREN182",
-    "title": "Contemporary Fiction in French",
-    "campus": "sc",
+    "title": "Cannibalizing Surrealism",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -13652,7 +13802,7 @@
   {
     "code": "FREN189",
     "title": "French Across the Curriculum",
-    "campus": "sc",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -13663,8 +13813,8 @@
   },
   {
     "code": "FREN191",
-    "title": "Senior Thesis in French Studies",
-    "campus": "sc",
+    "title": "Senior Thesis",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -13687,8 +13837,8 @@
   },
   {
     "code": "FREN199",
-    "title": "IS: French Studies",
-    "campus": "sc",
+    "title": "Independent Study in French",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -13717,31 +13867,31 @@
   },
   {
     "code": "FS001",
-    "title": "Life in Latn American Metropolis",
+    "title": "Writing About Animals",
     "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "FS002",
-    "title": "Not Just Gods and Gladiators",
+    "title": "On Memory",
     "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "FS003",
-    "title": "Nutrition in the Modern World",
+    "title": "Humor in Art & Visual Culture",
     "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "FS004",
-    "title": "Speculative Feminisms",
+    "title": "Is there a Science of Dreaming?",
     "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "FS005",
-    "title": "Selective Science",
+    "title": "The Art of Octavia Butler",
     "campus": "pz",
     "credits": 3.0
   },
@@ -13753,79 +13903,79 @@
   },
   {
     "code": "FS007",
-    "title": "Impossibilities: Gender & Utopia",
+    "title": "Intro to Asian Amer Pop Culture",
     "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "FS008",
-    "title": "LA: Culture & Environment",
-    "campus": "pz",
-    "credits": 3.0
-  },
-  {
-    "code": "FS009",
     "title": "Asians in America",
     "campus": "pz",
     "credits": 3.0
   },
   {
+    "code": "FS009",
+    "title": "The Literate Brain",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "FS010",
-    "title": "Experimental Film in Latn Amerca",
+    "title": "The Examined (College) Life\"\"",
     "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "FS011",
-    "title": "Observing Color",
+    "title": "Visual Evidence",
     "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "FS012",
-    "title": "Psychology of Cricket",
+    "title": "The Politics of Breakfast",
     "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "FS013",
-    "title": "Graffiti and Street Art",
+    "title": "Exploring Natural Disasters",
     "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "FS014",
-    "title": "Mindfulness",
-    "campus": "pz",
-    "credits": 3.0
-  },
-  {
-    "code": "FS015",
     "title": "La Familia",
     "campus": "pz",
     "credits": 3.0
   },
   {
+    "code": "FS015",
+    "title": "What Is Human?",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "FS016",
-    "title": "What is Human?",
+    "title": "American Political Cultures",
     "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "FS017",
-    "title": "Understanding Change",
+    "title": "Love and Loathing in Los Angeles",
     "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "FS018",
-    "title": "What's True",
+    "title": "World in a nutshell",
     "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "FS019",
-    "title": "Atheism and Secularity",
+    "title": "Drug Development & Innovation",
     "campus": "pz",
     "credits": 3.0
   },
@@ -13993,25 +14143,25 @@
   },
   {
     "code": "GEOL123",
-    "title": "Lab, Neotectonics of So. Calif.",
+    "title": "Neotectonics of SoCal w/Lab",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "GEOL125",
-    "title": "Lab, Earth History",
+    "title": "Earth History with Laboratory",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "GEOL127",
-    "title": "Lab, Mineralogy",
+    "title": "Mineralogy w/Laboratory",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "GEOL129",
-    "title": "Lab, Geophysics",
+    "title": "Geophysics with Laboratory",
     "campus": "po",
     "credits": 3.0
   },
@@ -14023,7 +14173,7 @@
   },
   {
     "code": "GEOL131",
-    "title": "Lab, Physical Volcanology",
+    "title": "Physical Volcanology w/Lab",
     "campus": "po",
     "credits": 3.0
   },
@@ -14047,25 +14197,25 @@
   },
   {
     "code": "GEOL181",
-    "title": "Lab, Igneous/Metamorphic Petrol",
+    "title": "Ign&Metamorphic Petrology w/Lab",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "GEOL183",
-    "title": "Lab, Sedimentology",
+    "title": "Sedimentology w/Laboratory",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "GEOL185",
-    "title": "Lab, Structural Geology",
+    "title": "Structural Geology",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "GEOL189C",
-    "title": "Oceans on a Habitable Planet",
+    "title": "Global Biogeochemical Cycles",
     "campus": "po",
     "credits": 3.0
   },
@@ -14120,12 +14270,12 @@
   {
     "code": "GERM001",
     "title": "Elementary German 1",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "GERM002",
-    "title": "Elementary German 2",
+    "title": "Introductory German",
     "campus": "sc",
     "credits": 3.0
   },
@@ -14156,19 +14306,19 @@
   {
     "code": "GERM033",
     "title": "Intermediate German",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "GERM044",
     "title": "Advanced German",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "GERM101",
     "title": "Introduction to German Culture",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -14191,8 +14341,8 @@
   },
   {
     "code": "GERM103",
-    "title": "A History of German Film",
-    "campus": "sc",
+    "title": "Intro to German Media and Film",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -14270,7 +14420,7 @@
   {
     "code": "GERM154",
     "title": "Great German Fiction",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -14299,14 +14449,14 @@
   },
   {
     "code": "GERM189",
-    "title": "German Across the Curriculum",
-    "campus": "sc",
+    "title": "German Language Component",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "GERM191",
     "title": "Senior Thesis in German",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -14449,7 +14599,7 @@
   },
   {
     "code": "GFS120",
-    "title": "Women and Human Rights Discourse",
+    "title": "Women and Human Rights",
     "campus": "pz",
     "credits": 3.0
   },
@@ -14527,7 +14677,7 @@
   },
   {
     "code": "GOVT030",
-    "title": "Washington Internship",
+    "title": "Internship:Govt/Politics/Pub Pol",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -14557,7 +14707,7 @@
   },
   {
     "code": "GOVT055",
-    "title": "Empirical Methods",
+    "title": "Intro Research Methods in PolSci",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -14575,13 +14725,13 @@
   },
   {
     "code": "GOVT070",
-    "title": "Intro to International Politics",
-    "campus": "pz",
+    "title": "Introduction to Int'l Politics",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "GOVT070H",
-    "title": "Intro to Int'l Politics (Honors)",
+    "title": "Introduction to Int'l Politics",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -14617,13 +14767,13 @@
   },
   {
     "code": "GOVT097",
-    "title": "Public Policy Analysis",
+    "title": "Public Policy Anaylsis",
     "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "GOVT100",
-    "title": "Policy Lab",
+    "title": "Public Policy Data Analysis/Lab",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -14641,7 +14791,7 @@
   },
   {
     "code": "GOVT103",
-    "title": "State, Local Politics, & Policy",
+    "title": "Presidency & the Constitution",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -14821,7 +14971,7 @@
   },
   {
     "code": "GOVT125",
-    "title": "President & US Foreign Policy",
+    "title": "Readings in Amer Natnl Politics",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -14845,13 +14995,13 @@
   },
   {
     "code": "GOVT127",
-    "title": "Washington Research Project",
+    "title": "Research on Political Process",
     "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "GOVT128",
-    "title": "The University Blacklist",
+    "title": "Ethics and American Democracy",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -14881,7 +15031,7 @@
   },
   {
     "code": "GOVT131",
-    "title": "Pol History of the Middle East",
+    "title": "Heroes, Villains, and Clowns",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -15061,7 +15211,7 @@
   },
   {
     "code": "GOVT144D",
-    "title": "Democracy and Dictatorship",
+    "title": "Democracy in Devel. Countries",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -15169,7 +15319,7 @@
   },
   {
     "code": "GOVT156E",
-    "title": "War II: Film",
+    "title": "Asian Security",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -15217,7 +15367,7 @@
   },
   {
     "code": "GOVT162",
-    "title": "CS Lewis, Ethics & Politics",
+    "title": "Comtemporary Political Phil",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -15499,8 +15649,8 @@
   },
   {
     "code": "GOVT199",
-    "title": "Senior Thesis",
-    "campus": "pz",
+    "title": "Independent Study in Government",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -15512,13 +15662,13 @@
   {
     "code": "GREK001",
     "title": "Introductory Classical Greek",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "GREK002",
     "title": "Introductory Classical Greek",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -15529,14 +15679,14 @@
   },
   {
     "code": "GREK033",
-    "title": "Intermediate Classical Greek",
-    "campus": "sc",
+    "title": "Intermediate Greek",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "GREK044",
-    "title": "Advanced Greek",
-    "campus": "sc",
+    "title": "Advanced Greek Readings",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -15595,7 +15745,7 @@
   },
   {
     "code": "GRMT131",
-    "title": "Germany Today",
+    "title": "Topics in Public German Discours",
     "campus": "po",
     "credits": 3.0
   },
@@ -15660,6 +15810,12 @@
     "credits": 3.0
   },
   {
+    "code": "GWS",
+    "title": "Gender/Women's St: Dir Readings",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "GWS026",
     "title": "Intro Gender and Women's Studies",
     "campus": "po",
@@ -15715,7 +15871,7 @@
   },
   {
     "code": "GWS183",
-    "title": "Transnational Feminist Theories",
+    "title": "Transnational Sexualities",
     "campus": "po",
     "credits": 3.0
   },
@@ -15805,14 +15961,14 @@
   },
   {
     "code": "HIST011",
-    "title": "The World Since 1492",
-    "campus": "pz",
+    "title": "Medieval Mediterranean",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "HIST012",
-    "title": "History of the Human Sciences",
-    "campus": "pz",
+    "title": "Saints and Society",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -15829,8 +15985,8 @@
   },
   {
     "code": "HIST017",
-    "title": "Hist/Pol Econ of Nat Resources",
-    "campus": "pz",
+    "title": "Chicano/Latino History",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -15841,19 +15997,19 @@
   },
   {
     "code": "HIST020",
-    "title": "Crisis & Revolution",
-    "campus": "sc",
+    "title": "US Colonial Era to Gilded Age",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "HIST021",
-    "title": "The World Since 1492",
-    "campus": "pz",
+    "title": "Power in the US",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "HIST022",
-    "title": "Middle East/N Africa Since 1500",
+    "title": "History of the Disciplines",
     "campus": "pz",
     "credits": 3.0
   },
@@ -15871,8 +16027,8 @@
   },
   {
     "code": "HIST025",
-    "title": "US History Before 1877",
-    "campus": "pz",
+    "title": "All Power to the People",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -15907,20 +16063,20 @@
   },
   {
     "code": "HIST034",
-    "title": "White/Off White:Racial Privilege",
-    "campus": "pz",
+    "title": "History of Mexico",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "HIST035",
-    "title": "Hist of Middle East, 600-1500 AD",
-    "campus": "pz",
+    "title": "The Caribbean:Crucible Modernity",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "HIST036",
-    "title": "History of Modern Middle East",
-    "campus": "pz",
+    "title": "Women Latin Amer&Carib 1300-1900",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -15961,7 +16117,7 @@
   },
   {
     "code": "HIST043",
-    "title": "Middle East in Modern Times",
+    "title": "Middle East & North Africa 1500",
     "campus": "po",
     "credits": 3.0
   },
@@ -16015,20 +16171,20 @@
   },
   {
     "code": "HIST051",
-    "title": "Iran before & after 2 Revolutns",
-    "campus": "pz",
+    "title": "Modern South Asian Hist thru Lit",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST052",
-    "title": "Political Islam, 1798- Present",
-    "campus": "pz",
+    "title": "South Asian History: Intro",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST053",
-    "title": "Minorities in the Middle East",
-    "campus": "pz",
+    "title": "Everyday Life in South Asia",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -16039,20 +16195,20 @@
   },
   {
     "code": "HIST055",
-    "title": "Popular Protests in Middle East",
-    "campus": "pz",
+    "title": "Middle East: Muhammad-Mongols",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST056",
-    "title": "US History: 1877 to Present",
-    "campus": "pz",
+    "title": "Middle East: Ottomans to Present",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST057",
-    "title": "THe US in the Middle East",
-    "campus": "pz",
+    "title": "Gunpowder Empires",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -16069,14 +16225,14 @@
   },
   {
     "code": "HIST061",
-    "title": "Native American History",
-    "campus": "pz",
+    "title": "New Asia: China, Japan, Indones",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST062",
-    "title": "Embodying the Voice of History",
-    "campus": "pz",
+    "title": "China, Japan, Korea in 20th Cent",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -16099,8 +16255,8 @@
   },
   {
     "code": "HIST068",
-    "title": "Prison Autobiography",
-    "campus": "pz",
+    "title": "Disasters Ancient Mediterranean",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -16123,25 +16279,25 @@
   },
   {
     "code": "HIST071",
-    "title": "Modern Europe Since 1789",
-    "campus": "po",
+    "title": "Medieval Europe: 800-1300CE",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST072",
-    "title": "History of Women in the U.S.",
-    "campus": "sc",
+    "title": "Making Early ModEurope 1300-1800",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST073",
-    "title": "The Problem with Profit",
-    "campus": "pz",
+    "title": "Rise of Mod Europe 1750-Present",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST074",
-    "title": "Queering the Medieval? Holiness",
+    "title": "Holiness, Heresy and the Body",
     "campus": "pz",
     "credits": 3.0
   },
@@ -16153,32 +16309,32 @@
   },
   {
     "code": "HIST077",
-    "title": "Great Revolutions in Human Hist",
-    "campus": "pz",
+    "title": "European Social History",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST078",
-    "title": "Sex & Gender in Ancient Greece",
-    "campus": "pz",
+    "title": "Museums and Leadership",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST080",
-    "title": "Revolution and Intervention",
-    "campus": "po",
+    "title": "Sci/Tech Ancient/Medieval Worlds",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "HIST081",
-    "title": "Science & Tech in Early Modern",
-    "campus": "pz",
+    "title": "Sci and Tech Early Modern World",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "HIST082",
-    "title": "Modern Science",
-    "campus": "pz",
+    "title": "Science&Technol in Modern World",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -16195,7 +16351,7 @@
   },
   {
     "code": "HIST085",
-    "title": "The History of Techno-Utopias",
+    "title": "Innovation & SOC Plan in US HIST",
     "campus": "pz",
     "credits": 3.0
   },
@@ -16207,8 +16363,8 @@
   },
   {
     "code": "HIST090",
-    "title": "Individual and Society",
-    "campus": "sc",
+    "title": "Early American Capitalism",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -16237,14 +16393,14 @@
   },
   {
     "code": "HIST095",
-    "title": "Africa from Antiquity to 1500",
-    "campus": "pz",
+    "title": "Intro to Latin-American Cultures",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST096",
-    "title": "Africa from 1500 to 1870",
-    "campus": "pz",
+    "title": "The Amazon",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -16255,8 +16411,8 @@
   },
   {
     "code": "HIST098",
-    "title": "Palestine and Israel",
-    "campus": "pz",
+    "title": "The Americas: Transnatnl Relatns",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -16339,7 +16495,7 @@
   },
   {
     "code": "HIST100N",
-    "title": "Mexico-U.S. Border (CP)",
+    "title": "Mexico-United States Border",
     "campus": "po",
     "credits": 3.0
   },
@@ -16501,7 +16657,7 @@
   },
   {
     "code": "HIST101K",
-    "title": "Politics of Honor-Ancient Greece",
+    "title": "Topics in Ancient History",
     "campus": "po",
     "credits": 3.0
   },
@@ -16573,8 +16729,8 @@
   },
   {
     "code": "HIST105",
-    "title": "Achilles to Alexander",
-    "campus": "po",
+    "title": "Sex & Gender in Ancient World",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -16585,14 +16741,14 @@
   },
   {
     "code": "HIST107",
-    "title": "Dante and the Medieval World",
-    "campus": "sc",
+    "title": "Ancient & Medieval Historians",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST108",
-    "title": "History of Economic Thought",
-    "campus": "sc",
+    "title": "Asians in the Americas",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -16603,8 +16759,8 @@
   },
   {
     "code": "HIST110",
-    "title": "Renaissance Venice",
-    "campus": "sc",
+    "title": "Topics in Ancient History",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -16645,7 +16801,7 @@
   },
   {
     "code": "HIST110K",
-    "title": "Politics of Honor in Anc Greece",
+    "title": "Topics in Ancient History",
     "campus": "po",
     "credits": 3.0
   },
@@ -16693,8 +16849,8 @@
   },
   {
     "code": "HIST111",
-    "title": "Medieval Germany",
-    "campus": "po",
+    "title": "Topics in European History",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -16705,8 +16861,8 @@
   },
   {
     "code": "HIST112",
-    "title": "Energy & Humnty, Past, Prsnt, Ft",
-    "campus": "pz",
+    "title": "Topics in American History",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -16729,26 +16885,26 @@
   },
   {
     "code": "HIST113",
-    "title": "Venice and the Islamic East",
-    "campus": "sc",
+    "title": "US Environmental History",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST114",
-    "title": "Renaissance Gender Slaves Heresy",
-    "campus": "sc",
+    "title": "Race/Racism in Colonial Americas",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST115",
-    "title": "State Power Early Modern Europe",
-    "campus": "sc",
+    "title": "Women in Eur Intel/Cultural Hist",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST116",
-    "title": "Baroque Civilization",
-    "campus": "sc",
+    "title": "Slavery: A World History",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -16759,20 +16915,20 @@
   },
   {
     "code": "HIST117",
-    "title": "The Rise of Capitalism",
-    "campus": "sc",
+    "title": "Race & Ethnicity in Brazil",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST118",
-    "title": "Teaching US History: Practicum",
-    "campus": "pz",
+    "title": "Rise of Service work in the US",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST119",
-    "title": "Medieval Thought",
-    "campus": "pz",
+    "title": "The Sixties",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -16789,20 +16945,20 @@
   },
   {
     "code": "HIST120E",
-    "title": "American Suburbia & Its Conseq",
+    "title": "The 1920's",
     "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST121",
-    "title": "African American Music/Protest",
-    "campus": "pz",
+    "title": "US History Since 1945",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST122",
-    "title": "Religion & the Founding Fathers",
-    "campus": "pz",
+    "title": "American Schools",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -16813,14 +16969,14 @@
   },
   {
     "code": "HIST123",
-    "title": "Philosophy/History of Culture",
-    "campus": "sc",
+    "title": "History of the American West",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST124",
-    "title": "Paris & 19C Birth of Modernity",
-    "campus": "sc",
+    "title": "Rethinkng Amer Politics snc 1900",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -16832,43 +16988,43 @@
   {
     "code": "HIST125",
     "title": "Intro to Asian American History",
-    "campus": "pz",
+    "campus": "sc",
     "credits": 3.0
   },
   {
     "code": "HIST126",
-    "title": "Visual Culture in California",
-    "campus": "pz",
+    "title": "American Constitutional History",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST127",
-    "title": "Rousseau,Tocqueville,Foucault",
-    "campus": "sc",
+    "title": "Twentieth-Century US History",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "HIST128",
-    "title": "Public Art and Controversy",
-    "campus": "pz",
+    "title": "Immigration/Ethnicity/Race in US",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "HIST129",
-    "title": "Native Amer Environmental Hist",
-    "campus": "pz",
+    "title": "London & Paris in the 19th Cent.",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST130",
-    "title": "Schools of Cultural Criticism",
-    "campus": "sc",
+    "title": "Ottoman Power & Urban History",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST131",
-    "title": "Fundamentalism and Rationalism",
-    "campus": "pz",
+    "title": "The Jewish Experience in America",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -16879,8 +17035,8 @@
   },
   {
     "code": "HIST132",
-    "title": "Paris, Berlin & London in 1920s",
-    "campus": "sc",
+    "title": "Genocide/Hum-Rights 20thC Europe",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -16903,8 +17059,8 @@
   },
   {
     "code": "HIST133",
-    "title": "Freud/Derrida",
-    "campus": "sc",
+    "title": "Food and American Culture",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -16921,20 +17077,20 @@
   },
   {
     "code": "HIST134",
-    "title": "France/Algeria",
-    "campus": "sc",
+    "title": "Dostoevskii's Russia",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST135",
-    "title": "Destruction of European Jewry",
-    "campus": "sc",
+    "title": "European Unification: 1815-pres",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST136",
-    "title": "A History of the Police State",
-    "campus": "pz",
+    "title": "The Great War",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -16951,8 +17107,8 @@
   },
   {
     "code": "HIST138",
-    "title": "Disease, Identity, and Society",
-    "campus": "sc",
+    "title": "Europe's Total Wars",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -16969,8 +17125,8 @@
   },
   {
     "code": "HIST140",
-    "title": "Contemp Africa/Digital Archives",
-    "campus": "pz",
+    "title": "Gender/Revoltn Europe 1500-1900",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -16981,14 +17137,14 @@
   },
   {
     "code": "HIST141",
-    "title": "Americas:Race,Labor & Organizing",
-    "campus": "sc",
+    "title": "Design Activism",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST142",
-    "title": "Slavery & Slave Trading in Afric",
-    "campus": "pz",
+    "title": "Renaissance & Reformation Euro.",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -16999,8 +17155,8 @@
   },
   {
     "code": "HIST143",
-    "title": "Cuba/Bolivia/Vzla: Revolution",
-    "campus": "sc",
+    "title": "Slavery & Freedom in New World",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -17029,8 +17185,8 @@
   },
   {
     "code": "HIST144",
-    "title": "Haiti/Colombia/Maroons/Paramilit",
-    "campus": "sc",
+    "title": "Black Intellectual Thought",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -17041,20 +17197,20 @@
   },
   {
     "code": "HIST146",
-    "title": "Zapatistas/Mayan Rebels",
-    "campus": "sc",
+    "title": "Atlantic World of Slavery",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "HIST147",
-    "title": "American Art and the Civil War",
-    "campus": "pz",
+    "title": "Mughal India",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "HIST148",
-    "title": "Gender and Sexuality in Africa",
-    "campus": "pz",
+    "title": "Women in Euro History: 1450-1815",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -17083,7 +17239,7 @@
   },
   {
     "code": "HIST149B",
-    "title": "Radical Voices: Women of Lat Am",
+    "title": "Radical Voices",
     "campus": "sc",
     "credits": 3.0
   },
@@ -17095,8 +17251,8 @@
   },
   {
     "code": "HIST150",
-    "title": "Journalism in America",
-    "campus": "pz",
+    "title": "Technology and Medicine",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -17107,8 +17263,8 @@
   },
   {
     "code": "HIST151",
-    "title": "Atomic Bomb in American Culture",
-    "campus": "pz",
+    "title": "Science in Fiction",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -17119,20 +17275,20 @@
   },
   {
     "code": "HIST152",
-    "title": "The Great Depression 1929-1941",
-    "campus": "pz",
+    "title": "History of Modern Physics",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "HIST153",
-    "title": "History of Anthropological Theor",
-    "campus": "pz",
+    "title": "Slave Women in Antebellum Amer",
+    "campus": "sc",
     "credits": 3.0
   },
   {
     "code": "HIST154",
-    "title": "The Old South and Modern Memory",
-    "campus": "sc",
+    "title": "Makers of Modern India/Pakistan",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -17155,14 +17311,14 @@
   },
   {
     "code": "HIST158",
-    "title": "US Civil War and Reconstruction",
-    "campus": "pz",
+    "title": "Japanese Empire",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST159",
-    "title": "Gender+Masculnty:Euro Enlighten",
-    "campus": "sc",
+    "title": "Mid East/Central Asia 1200-pres",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -17173,20 +17329,20 @@
   },
   {
     "code": "HIST160",
-    "title": "Violent Dissent in U.S. Politics",
-    "campus": "pz",
+    "title": "Women and Politics in Latin Amer",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "HIST161",
-    "title": "Food/Culture/Power in Asia/Pacif",
-    "campus": "po",
+    "title": "Modern Korean History",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST162",
-    "title": "Borders in East Asia",
-    "campus": "po",
+    "title": "The Making of Pre-Modern China",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -17197,14 +17353,14 @@
   },
   {
     "code": "HIST163",
-    "title": "Propaganda",
-    "campus": "pz",
+    "title": "Modern Chinese History",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST164",
-    "title": "Islam in Africa",
-    "campus": "pz",
+    "title": "Mao's China",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -17215,26 +17371,26 @@
   },
   {
     "code": "HIST165",
-    "title": "Baghdad and Constantinople",
-    "campus": "pz",
+    "title": "Middle East in Modern Times",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST166",
-    "title": "Self and Society",
-    "campus": "sc",
+    "title": "Late Imperial China 1400-1911",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST166IOSC",
-    "title": "Self and Society",
+    "title": "Political & Cultural Criticism",
     "campus": "sc",
     "credits": 3.0
   },
   {
     "code": "HIST167",
-    "title": "US Urban Space, Race and Policy",
-    "campus": "sc",
+    "title": "Gender & History in South Asia",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -17251,8 +17407,8 @@
   },
   {
     "code": "HIST168",
-    "title": "Diaspora, Gender, and Identity",
-    "campus": "pz",
+    "title": "China & World War II",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -17269,8 +17425,8 @@
   },
   {
     "code": "HIST169A",
-    "title": "Freedom+Race:Citizenship+Slavery",
-    "campus": "sc",
+    "title": "Topics in Middle Eastern History",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -17299,44 +17455,44 @@
   },
   {
     "code": "HIST172",
-    "title": "Empire and Sexuality",
-    "campus": "pz",
-    "credits": 3.0
-  },
-  {
-    "code": "HIST173",
-    "title": "Religion, Violence & Tolerance",
-    "campus": "pz",
-    "credits": 3.0
-  },
-  {
-    "code": "HIST174",
-    "title": "The U.S. in the 1960s",
-    "campus": "sc",
-    "credits": 3.0
-  },
-  {
-    "code": "HIST175",
-    "title": "War,Empire+Society US 1898-Pres",
-    "campus": "sc",
-    "credits": 3.0
-  },
-  {
-    "code": "HIST176",
-    "title": "Early American Families",
+    "title": "Nature/Environment Ancient World",
     "campus": "cmc",
     "credits": 3.0
   },
   {
-    "code": "HIST177",
-    "title": "Fords, Flappers+Fundamentalists",
+    "code": "HIST173",
+    "title": "Black Intellectuals & Polit Race",
     "campus": "sc",
     "credits": 3.0
   },
   {
-    "code": "HIST178",
-    "title": "Cultures:Conflict,Consenses,Diff",
+    "code": "HIST174",
+    "title": "US & Comparative Military System",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST175",
+    "title": "Women and Politics in America",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST176",
+    "title": "Civil Rights Movement Modern Era",
     "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST177",
+    "title": "Tpcs in European Social History",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HIST178",
+    "title": "Theories of History",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -17401,8 +17557,8 @@
   },
   {
     "code": "HIST180",
-    "title": "History in a Time of Crisis",
-    "campus": "sc",
+    "title": "History of European Aristocracy",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -17413,20 +17569,20 @@
   },
   {
     "code": "HIST182",
-    "title": "Chinese Medicine: Cult,Hist,Body",
-    "campus": "pz",
-    "credits": 3.0
-  },
-  {
-    "code": "HIST183",
-    "title": "The Fall of Rome: End of Empire",
+    "title": "Human Health/Disease in US Hist",
     "campus": "cmc",
     "credits": 3.0
   },
   {
+    "code": "HIST183",
+    "title": "Science and Tech: Amer Culture",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "HIST184",
-    "title": "Women and Gender, 1350 - 1700",
-    "campus": "pz",
+    "title": "Cult of Fascism in 20th C. Europ",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -17437,8 +17593,8 @@
   },
   {
     "code": "HIST185",
-    "title": "Information Revolutions x.0&z.0",
-    "campus": "pz",
+    "title": "Making History",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -17461,14 +17617,14 @@
   },
   {
     "code": "HIST187",
-    "title": "History & Politcs of World Socc",
-    "campus": "pz",
+    "title": "After Holocaust, After Gulag",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST188",
-    "title": "Anxiety in the Age of Reason",
-    "campus": "pz",
+    "title": "Making Modern Iran & Afghanistan",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -17521,26 +17677,26 @@
   },
   {
     "code": "HIST190",
-    "title": "Seminar in History",
-    "campus": "sc",
+    "title": "Race & American Cities",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST191",
-    "title": "Senior Thesis in History",
-    "campus": "sc",
+    "title": "Advanced Topics in Asian History",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST192",
-    "title": "Senior Thesis in History",
-    "campus": "sc",
+    "title": "Senior Essay",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "HIST193",
-    "title": "Senior Tutorial",
-    "campus": "po",
+    "title": "The Great Men of India",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -17557,14 +17713,14 @@
   },
   {
     "code": "HIST196",
-    "title": "Explorations in Deep Time",
-    "campus": "pz",
+    "title": "Advanced Topics in American Hist",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "HIST197",
-    "title": "Topics in Historical Study",
-    "campus": "sc",
+    "title": "Independent Study: History",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -17581,7 +17737,7 @@
   },
   {
     "code": "HIST197D",
-    "title": "Pandemics and Globalized World",
+    "title": "Topics in Historical Study",
     "campus": "sc",
     "credits": 3.0
   },
@@ -17617,14 +17773,14 @@
   },
   {
     "code": "HIST198",
-    "title": "Independent Internship",
-    "campus": "sc",
+    "title": "Summer Reading & Research",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "HIST199",
-    "title": "Independent Study in History",
-    "campus": "sc",
+    "title": "Indep St Hist & Africana Studies",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -17676,6 +17832,12 @@
     "credits": 3.0
   },
   {
+    "code": "HMCBELECTHM",
+    "title": "MCB Major Tech Elective",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "HMSC087F",
     "title": "Black France",
     "campus": "sc",
@@ -17707,7 +17869,7 @@
   },
   {
     "code": "HMSC123",
-    "title": "Philosophy/History of Culture",
+    "title": "Philosophy & History of Culture",
     "campus": "sc",
     "credits": 3.0
   },
@@ -17719,7 +17881,7 @@
   },
   {
     "code": "HMSC133",
-    "title": "Modernity and the Unconscious",
+    "title": "Freud/Derrida",
     "campus": "sc",
     "credits": 3.0
   },
@@ -17737,7 +17899,7 @@
   },
   {
     "code": "HMSC136",
-    "title": "Critical Theory & Modern Culture",
+    "title": "Cultural Critique & Capitalism",
     "campus": "sc",
     "credits": 3.0
   },
@@ -18054,9 +18216,33 @@
     "credits": 3.0
   },
   {
+    "code": "HUMCONC",
+    "title": "Humanities Conc",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "HUMCONC1",
     "title": "Humanities Conc",
     "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "HUMSEM",
+    "title": "Humanities Seminar",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "I/C",
+    "title": "Intercollegiate Team Waiver",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "ID",
+    "title": "Sr Exper Thes:Dual Sci Majors",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -18067,8 +18253,8 @@
   },
   {
     "code": "ID026",
-    "title": "Introduction to Women's Studies",
-    "campus": "pz",
+    "title": "Intro to Women's Studies",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -18139,8 +18325,8 @@
   },
   {
     "code": "ID099",
-    "title": "MMUF Seminar",
-    "campus": "sc",
+    "title": "Civic Leadership, Resp, & Involv",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -18205,14 +18391,14 @@
   },
   {
     "code": "ID110",
-    "title": "Major Course REQ Met",
-    "campus": "sc",
+    "title": "Science & Alternative Medicine",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "ID111",
-    "title": "Minor REQ met",
-    "campus": "sc",
+    "title": "Lessons Learned on Study Abroad",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -18337,8 +18523,8 @@
   },
   {
     "code": "ID199",
-    "title": "Indep St: Interdisciplinary St",
-    "campus": "sc",
+    "title": "Independent Study",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -18517,7 +18703,7 @@
   },
   {
     "code": "IIS113",
-    "title": "Science, Politics & Alt Medicine",
+    "title": "Science Politics & Alt Medicine",
     "campus": "pz",
     "credits": 3.0
   },
@@ -18547,7 +18733,7 @@
   },
   {
     "code": "IIS122",
-    "title": "Socl & Pol Movmnts in Third Wrld",
+    "title": "Contemp Pol & Soc Movts:3rd Wrld",
     "campus": "pz",
     "credits": 3.0
   },
@@ -18697,8 +18883,8 @@
   },
   {
     "code": "INT099",
-    "title": "Internship",
-    "campus": "pz",
+    "title": "Internship (Non-Credit)",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -18741,6 +18927,24 @@
     "code": "INT199J",
     "title": "Internship: Non-Profit",
     "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "IPSHMC",
+    "title": "HMC IPS Course",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "IPSOMC",
+    "title": "Off Campus IPS Course",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "IR",
+    "title": "Intl Relations:Directed Readings",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -18853,7 +19057,7 @@
   },
   {
     "code": "IST302",
-    "title": "Databases",
+    "title": "Databases and Big Data",
     "campus": "cgu",
     "credits": 3.0
   },
@@ -18877,7 +19081,7 @@
   },
   {
     "code": "IST311",
-    "title": "Mobile Application Development",
+    "title": "Persuasive Technologies",
     "campus": "cgu",
     "credits": 3.0
   },
@@ -19033,7 +19237,7 @@
   },
   {
     "code": "ITAL133",
-    "title": "Contemporary Italy",
+    "title": "Contemporary Italian Literature",
     "campus": "sc",
     "credits": 3.0
   },
@@ -19069,7 +19273,7 @@
   },
   {
     "code": "ITAL142",
-    "title": "Italian Cinema & Literature",
+    "title": "Italian Literature & Cinema",
     "campus": "sc",
     "credits": 3.0
   },
@@ -19213,7 +19417,7 @@
   },
   {
     "code": "JAPN125H",
-    "title": "Continuing Japanese",
+    "title": "Japanese Through Current Media",
     "campus": "po",
     "credits": 3.0
   },
@@ -19321,7 +19525,7 @@
   },
   {
     "code": "JPNT174",
-    "title": "(Post-) Modrn Jpn Lit & Cinema",
+    "title": "Modern Japanese Literature",
     "campus": "po",
     "credits": 3.0
   },
@@ -19369,8 +19573,8 @@
   },
   {
     "code": "JWST199",
-    "title": "Independent St: Jewish Studies",
-    "campus": "sc",
+    "title": "Independent Study",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -19465,8 +19669,8 @@
   },
   {
     "code": "LAST191",
-    "title": "Senior Thesis:Latin American St",
-    "campus": "sc",
+    "title": "Senior Thesis",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -19502,31 +19706,31 @@
   {
     "code": "LATN001",
     "title": "Introductory Latin",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "LATN002",
     "title": "Introductory Latin",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "LATN022",
-    "title": "Advanced Introductory Latin",
-    "campus": "sc",
+    "title": "Introductory Latin Accelerated",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "LATN033",
     "title": "Intermediate Latin",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "LATN044",
     "title": "Advanced Latin Readings",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -19650,9 +19854,15 @@
     "credits": 3.0
   },
   {
+    "code": "LGCS",
+    "title": "Independent Study",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
     "code": "LGCS010",
     "title": "Introduction to Linguistics",
-    "campus": "pz",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -19730,7 +19940,7 @@
   {
     "code": "LGCS114",
     "title": "Linguistic Discrimination",
-    "campus": "pz",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -19747,7 +19957,7 @@
   },
   {
     "code": "LGCS118",
-    "title": "Morphosyntactic Diversity",
+    "title": "Principles of Human Interaction",
     "campus": "po",
     "credits": 3.0
   },
@@ -19819,7 +20029,7 @@
   },
   {
     "code": "LGCS166",
-    "title": "Tpcs in Soclng:Ethnicity in Mdia",
+    "title": "Language & Gender in Disney",
     "campus": "pz",
     "credits": 3.0
   },
@@ -19903,14 +20113,14 @@
   },
   {
     "code": "LGCS191",
-    "title": "Senior Thesis:Ling Cognitive Sci",
-    "campus": "sc",
+    "title": "Senior Thesis in Ling & Cog Sci",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "LGCS193",
     "title": "Senior Comprehensive Exam",
-    "campus": "pz",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -19921,8 +20131,8 @@
   },
   {
     "code": "LGCS198",
-    "title": "Independent Internship",
-    "campus": "sc",
+    "title": "Summer Reading & Research",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -19986,6 +20196,12 @@
     "credits": 3.0
   },
   {
+    "code": "LIT",
+    "title": "U.S. Latinx Literature",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "LIT020",
     "title": "Freshman Honors Seminar",
     "campus": "cmc",
@@ -19993,7 +20209,7 @@
   },
   {
     "code": "LIT030",
-    "title": "Introduction to Video Art",
+    "title": "Expository Writing",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -20227,7 +20443,7 @@
   },
   {
     "code": "LIT088",
-    "title": "War and Peace",
+    "title": "Beast Within: Literary Animals",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -20347,8 +20563,8 @@
   },
   {
     "code": "LIT103",
-    "title": "The Idea of Poetry",
-    "campus": "cmc",
+    "title": "Third Cinema",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -20371,8 +20587,8 @@
   },
   {
     "code": "LIT107",
-    "title": "Modern Drama",
-    "campus": "cmc",
+    "title": "Creative Writing",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -20671,7 +20887,7 @@
   },
   {
     "code": "LIT160",
-    "title": "Science & Faith in Modern Lit",
+    "title": "Caribbean Literature",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -20683,13 +20899,13 @@
   },
   {
     "code": "LIT162",
-    "title": "Literature & the Visual Arts",
+    "title": "African Literature",
     "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "LIT163",
-    "title": "Leadership in Literature & Film",
+    "title": "North African Literature/Culture",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -20701,7 +20917,7 @@
   },
   {
     "code": "LIT165",
-    "title": "Nietzsche, Marx & Freud",
+    "title": "Caribbean Women Writers",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -20989,8 +21205,8 @@
   },
   {
     "code": "MATH001",
-    "title": "Math Philosophy & the Real World",
-    "campus": "pz",
+    "title": "Math, Phil & the Real World",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -21013,7 +21229,7 @@
   },
   {
     "code": "MATH008",
-    "title": "Philosophy of Mathematics",
+    "title": "Mathematics, Art & Aesthetics",
     "campus": "pz",
     "credits": 3.0
   },
@@ -21085,8 +21301,8 @@
   },
   {
     "code": "MATH015",
-    "title": "Journeys in Mathematics",
-    "campus": "sc",
+    "title": "Application & Art of Calculus",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -21104,7 +21320,7 @@
   {
     "code": "MATH020",
     "title": "Elementary Functions",
-    "campus": "sc",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -21122,7 +21338,7 @@
   {
     "code": "MATH023",
     "title": "Transcendental Functions",
-    "campus": "sc",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -21133,14 +21349,14 @@
   },
   {
     "code": "MATH029",
-    "title": "Calculus & Applied Math",
-    "campus": "po",
+    "title": "Late Transcendental Calculus",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "MATH030",
     "title": "Calculus I",
-    "campus": "sc",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -21164,7 +21380,7 @@
   {
     "code": "MATH031",
     "title": "Calculus II",
-    "campus": "sc",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -21181,14 +21397,14 @@
   },
   {
     "code": "MATH031S",
-    "title": "Calc II w/Apps to Science",
+    "title": "Calc II w/Apps to Life Sciences",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "MATH032",
     "title": "Calculus III",
-    "campus": "sc",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -21199,14 +21415,14 @@
   },
   {
     "code": "MATH032S",
-    "title": "Calc III w/Apps to the Sciences",
+    "title": "Calc III w/Apps to Life Sciences",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "MATH035",
-    "title": "Subcalculus Seminar",
-    "campus": "sc",
+    "title": "Probability and Statistics",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -21284,7 +21500,7 @@
   {
     "code": "MATH052",
     "title": "Introduction to Statistics",
-    "campus": "pz",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -21296,7 +21512,7 @@
   {
     "code": "MATH055",
     "title": "Discrete Mathematics",
-    "campus": "sc",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -21313,7 +21529,7 @@
   },
   {
     "code": "MATH058",
-    "title": "Lab, Intro to Statistics",
+    "title": "Introduction to Statistics w/Lab",
     "campus": "po",
     "credits": 3.0
   },
@@ -21331,8 +21547,8 @@
   },
   {
     "code": "MATH060",
-    "title": "Linear Algebra",
-    "campus": "sc",
+    "title": "Multivariable Calculus",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -21428,19 +21644,19 @@
   {
     "code": "MATH101",
     "title": "Introduction to Analysis",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "MATH102",
-    "title": "Differential Equations+Modeling",
-    "campus": "sc",
+    "title": "Differential Equations/Modeling",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "MATH103",
-    "title": "Lab, Combinatorial Math",
-    "campus": "po",
+    "title": "Combinatorics",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -21500,13 +21716,13 @@
   {
     "code": "MATH111",
     "title": "Differential Equations",
-    "campus": "sc",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "MATH112",
-    "title": "Discrete Dynamical Sys & Chaos",
-    "campus": "po",
+    "title": "Intro Dynamical Systems & Chaos",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -21523,20 +21739,20 @@
   },
   {
     "code": "MATH119",
-    "title": "Mathematics Research Circle",
-    "campus": "po",
+    "title": "Advanced Mathematical Biology",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "MATH131",
-    "title": "Principles of Real Analysis I",
-    "campus": "sc",
+    "title": "Mathematical Analysis I",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "MATH132",
-    "title": "Principles of Real Analysis II",
-    "campus": "po",
+    "title": "Mathematical Analysis II",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -21554,7 +21770,7 @@
   {
     "code": "MATH135",
     "title": "Complex Analysis",
-    "campus": "sc",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -21565,20 +21781,20 @@
   },
   {
     "code": "MATH137",
-    "title": "Real & Functional Analysis I",
-    "campus": "po",
+    "title": "Graduate Analysis I",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "MATH138",
-    "title": "Real & Functional Analysis II",
-    "campus": "po",
+    "title": "Graduate Analysis II",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "MATH139",
     "title": "Fourier Analysis",
-    "campus": "sc",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -21596,7 +21812,7 @@
   {
     "code": "MATH142",
     "title": "Differential Geometry",
-    "campus": "pz",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -21607,14 +21823,14 @@
   },
   {
     "code": "MATH144",
-    "title": "Classical and Modern Geometries",
-    "campus": "sc",
+    "title": "Algebraic Topology",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "MATH145",
-    "title": "Topics Topology:Calc Variations",
-    "campus": "pz",
+    "title": "Topics in Geometry and Topology",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -21632,7 +21848,7 @@
   {
     "code": "MATH147",
     "title": "Topology",
-    "campus": "po",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -21661,14 +21877,14 @@
   },
   {
     "code": "MATH150",
-    "title": "Methods in Biostatistics",
+    "title": "Stat Method Clinical Trials Data",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "MATH151",
     "title": "Probability",
-    "campus": "po",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -21680,13 +21896,13 @@
   {
     "code": "MATH152",
     "title": "Statistical Theory",
-    "campus": "po",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "MATH153",
     "title": "Bayesian Statistics",
-    "campus": "po",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -21698,7 +21914,7 @@
   {
     "code": "MATH155",
     "title": "Time Series",
-    "campus": "po",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -21722,13 +21938,13 @@
   {
     "code": "MATH158",
     "title": "Statistical Linear Models",
-    "campus": "po",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "MATH159",
-    "title": "Advanced Topics in Statistics",
-    "campus": "po",
+    "title": "Design & Analysis of Experiments",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -21794,43 +22010,43 @@
   {
     "code": "MATH171",
     "title": "Abstract Algebra I",
-    "campus": "sc",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "MATH172",
-    "title": "Abstrct Algebra II:Galois Theory",
-    "campus": "po",
+    "title": "AbstractAlgebra II/Galois Theory",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "MATH173",
     "title": "Advanced Linear Algebra",
-    "campus": "sc",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "MATH174",
-    "title": "Abstract Alg II: Represent Thry",
-    "campus": "po",
+    "title": "Representation Theory/AbstrAlgII",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "MATH175",
-    "title": "Number Theory and Cryptography",
-    "campus": "sc",
+    "title": "Number Theory",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "MATH176",
-    "title": "Analytic Number Theory",
-    "campus": "sc",
+    "title": "Algebraic Geometry",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "MATH177",
-    "title": "Combinatorial Group Theory",
-    "campus": "pz",
+    "title": "Advanced Topics in Algebra",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -21841,14 +22057,14 @@
   },
   {
     "code": "MATH180",
-    "title": "Intro to PDEs",
-    "campus": "po",
+    "title": "Intro to Partial Differential Eq",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "MATH181",
     "title": "Dynamical Systems",
-    "campus": "po",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -21859,8 +22075,8 @@
   },
   {
     "code": "MATH183",
-    "title": "Modeling and Simulation",
-    "campus": "sc",
+    "title": "Mathematical Modeling (CP)",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -21877,14 +22093,14 @@
   },
   {
     "code": "MATH186",
-    "title": "Stochastic Operations Research",
+    "title": "Stochastic Meth Operatn Research",
     "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "MATH187",
-    "title": "Deterministic Operations Resrch",
-    "campus": "po",
+    "title": "Operations Research",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -22045,14 +22261,14 @@
   },
   {
     "code": "MATH190",
-    "title": "Senior Seminar in Mathematics",
-    "campus": "sc",
+    "title": "Sem in Mathematical Exposition",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "MATH191",
     "title": "Senior Thesis in Mathematics",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -22081,8 +22297,8 @@
   },
   {
     "code": "MATH197",
-    "title": "Selected Topics in Mathematics",
-    "campus": "po",
+    "title": "Senior Thesis in Mathematics",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -22099,14 +22315,14 @@
   },
   {
     "code": "MATH198",
-    "title": "Independent Internship: Math",
-    "campus": "sc",
+    "title": "Undergraduate Mathematics Forum",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "MATH199",
-    "title": "Independent Study in Mathematics",
-    "campus": "sc",
+    "title": "Mathematics Colloquium",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -22237,7 +22453,7 @@
   },
   {
     "code": "MATH368",
-    "title": "Numerical Methods Matrix Comp",
+    "title": "Advanced Numerical Analysis",
     "campus": "cgu",
     "credits": 3.0
   },
@@ -22255,7 +22471,7 @@
   },
   {
     "code": "MATH386",
-    "title": "Image Processing",
+    "title": "Graph Theory",
     "campus": "cgu",
     "credits": 3.0
   },
@@ -22333,7 +22549,7 @@
   },
   {
     "code": "MATH462",
-    "title": "Mathematics of Machine Learning",
+    "title": "Bayesian Meth & Machine Learning",
     "campus": "cgu",
     "credits": 3.0
   },
@@ -22352,6 +22568,12 @@
   {
     "code": "MATHELECT1HM",
     "title": "Mathematics Elective",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "MATHELECTHM",
+    "title": "Math Major/Minor Elective",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -22386,8 +22608,20 @@
     "credits": 3.0
   },
   {
+    "code": "MBIOLAB",
+    "title": "Biology Lab for Math-Bio Maj",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "MBIOREQ1",
     "title": "Mathematical Biology Requirement",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "MBIOSEM",
+    "title": "Biology Seminar for Math-Bio Maj",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -22417,7 +22651,7 @@
   },
   {
     "code": "MCSI195",
-    "title": "Divine Hiddeness",
+    "title": "Islam Beyond Ideolgical ...",
     "campus": "pz",
     "credits": 3.0
   },
@@ -22495,7 +22729,7 @@
   },
   {
     "code": "MGT306",
-    "title": "Business Analytics",
+    "title": "Quant Methods for Management",
     "campus": "cgu",
     "credits": 3.0
   },
@@ -22789,7 +23023,7 @@
   },
   {
     "code": "MGT402",
-    "title": "Asset Management Practicum",
+    "title": "Assets Management Practicum",
     "campus": "cgu",
     "credits": 3.0
   },
@@ -22801,7 +23035,7 @@
   },
   {
     "code": "MGT405",
-    "title": "Entrepreneurship and Innovation",
+    "title": "New Business Creation",
     "campus": "cgu",
     "credits": 3.0
   },
@@ -22819,7 +23053,7 @@
   },
   {
     "code": "MGT409",
-    "title": "Systems Thinking",
+    "title": "Managing Flow",
     "campus": "cgu",
     "credits": 3.0
   },
@@ -22963,7 +23197,7 @@
   },
   {
     "code": "MLLC001",
-    "title": "American Sign Language",
+    "title": "College Speech and Rhetoric",
     "campus": "pz",
     "credits": 3.0
   },
@@ -23202,6 +23436,12 @@
     "credits": 3.0
   },
   {
+    "code": "MS",
+    "title": "Media Studies: Directed Readings",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "MS003",
     "title": "Transatlantic Blk/Asian Film/Lit",
     "campus": "pz",
@@ -23269,20 +23509,20 @@
   },
   {
     "code": "MS049",
-    "title": "Introduction to Media Studies",
-    "campus": "sc",
+    "title": "Intro to Media Studies",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "MS050",
-    "title": "Intro to Film",
-    "campus": "pz",
+    "title": "Introduction to Film",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "MS051",
     "title": "Intro to Digital Media Studies",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -23317,8 +23557,8 @@
   },
   {
     "code": "MS057",
-    "title": "Intro to Game Design",
-    "campus": "sc",
+    "title": "Screenwriting",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -23335,8 +23575,8 @@
   },
   {
     "code": "MS060",
-    "title": "Media and Migration",
-    "campus": "pz",
+    "title": "Documentary: Fact and Fiction",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -23377,7 +23617,7 @@
   },
   {
     "code": "MS073",
-    "title": "Technology, Capitalism & Race",
+    "title": "Race, Theory and Media",
     "campus": "pz",
     "credits": 3.0
   },
@@ -23449,8 +23689,8 @@
   },
   {
     "code": "MS085",
-    "title": "Intro to Film in the Digital Age",
-    "campus": "pz",
+    "title": "Indep/Exper Film & Video",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -23498,7 +23738,7 @@
   {
     "code": "MS091",
     "title": "History of American Broadcasting",
-    "campus": "pz",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -23515,8 +23755,8 @@
   },
   {
     "code": "MS094",
-    "title": "Collaborative Art of Filmmaking",
-    "campus": "pz",
+    "title": "Transnational Asian Cinemas",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -23539,7 +23779,7 @@
   },
   {
     "code": "MS098",
-    "title": "Media of Middle East",
+    "title": "Cinematography",
     "campus": "pz",
     "credits": 3.0
   },
@@ -23557,8 +23797,8 @@
   },
   {
     "code": "MS101",
-    "title": "Asian Amer Media in Communities",
-    "campus": "pz",
+    "title": "Pomona Media Guild",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -23581,7 +23821,7 @@
   },
   {
     "code": "MS105",
-    "title": "Game Sound",
+    "title": "Transnational Media Theory",
     "campus": "pz",
     "credits": 3.0
   },
@@ -23629,7 +23869,7 @@
   },
   {
     "code": "MS113",
-    "title": "The Art of Gesture and Talk",
+    "title": "African Masculinities in Film",
     "campus": "pz",
     "credits": 3.0
   },
@@ -23671,19 +23911,19 @@
   },
   {
     "code": "MS120",
-    "title": "Video Games & Media Discourse",
-    "campus": "sc",
+    "title": "Animal Media Studies",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "MS121",
-    "title": "Cultural Politics of Self Care",
+    "title": "Mixed Reality",
     "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "MS123",
-    "title": "Embodying Identity in Practice",
+    "title": "Satire in Literature and Film",
     "campus": "pz",
     "credits": 3.0
   },
@@ -23713,8 +23953,8 @@
   },
   {
     "code": "MS131",
-    "title": "Interactive Narrative Design",
-    "campus": "sc",
+    "title": "The Two\" and Media\"",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -23851,7 +24091,7 @@
   },
   {
     "code": "MS149",
-    "title": "Theory& Aesthetics of Television",
+    "title": "Theory & Aesthetics of Televisn",
     "campus": "pz",
     "credits": 3.0
   },
@@ -23899,7 +24139,7 @@
   },
   {
     "code": "MS149T",
-    "title": "Seminar: Critical Studies",
+    "title": "Junior Seminar: Critical Studies",
     "campus": "po",
     "credits": 3.0
   },
@@ -23929,8 +24169,8 @@
   },
   {
     "code": "MS160",
-    "title": "Computational Photography II",
-    "campus": "sc",
+    "title": "Japanese Film: Canon to Fringe",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -23947,8 +24187,8 @@
   },
   {
     "code": "MS170",
-    "title": "Digital Cinema: Expr. Animation",
-    "campus": "pz",
+    "title": "DigitalCinema:ExpermntlAnimation",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -24038,7 +24278,7 @@
   {
     "code": "MS190",
     "title": "Senior Seminar",
-    "campus": "pz",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -24055,13 +24295,13 @@
   },
   {
     "code": "MS191",
-    "title": "Media Internship",
+    "title": "Senior Thesis in Media Studies",
     "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "MS192",
-    "title": "Advanced Media Project",
+    "title": "Senior Project in Media Studies",
     "campus": "pz",
     "credits": 3.0
   },
@@ -24085,14 +24325,14 @@
   },
   {
     "code": "MS197",
-    "title": "Media Praxis",
-    "campus": "pz",
+    "title": "Independent Study: Media Studies",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "MS198",
-    "title": "Independent Internship",
-    "campus": "sc",
+    "title": "Summer Reading & Research",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -24109,7 +24349,7 @@
   },
   {
     "code": "MSL001A",
-    "title": "Amer Mil Hist; Civil War-Present",
+    "title": "Analysis of Key 20th Cent Battle",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -24180,9 +24420,15 @@
     "credits": 3.0
   },
   {
+    "code": "MUS",
+    "title": "Bass Level I (Indiv Instruc)",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "MUS003",
     "title": "Fundamentals of Music",
-    "campus": "sc",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -24433,7 +24679,7 @@
   },
   {
     "code": "MUS071",
-    "title": "Music in Punjabi Culture",
+    "title": "Music in Africa",
     "campus": "po",
     "credits": 3.0
   },
@@ -24463,7 +24709,7 @@
   },
   {
     "code": "MUS077",
-    "title": "Jamaican Musical Aesthetics",
+    "title": "Music & Performance of Africa",
     "campus": "po",
     "credits": 3.0
   },
@@ -24475,19 +24721,19 @@
   },
   {
     "code": "MUS080",
-    "title": "Lab, Theory I",
+    "title": "Music Theory I",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "MUS081",
-    "title": "Lab, Theory II",
-    "campus": "po",
+    "title": "Introduction to Music",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "MUS082",
-    "title": "Lab, Theory III",
+    "title": "Music Theory III",
     "campus": "po",
     "credits": 3.0
   },
@@ -24541,8 +24787,8 @@
   },
   {
     "code": "MUS088",
-    "title": "Global Musical Instruments",
-    "campus": "po",
+    "title": "Introduction to Computer Music",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -24553,8 +24799,8 @@
   },
   {
     "code": "MUS089A",
-    "title": "Pop Music in East Asia",
-    "campus": "po",
+    "title": "Group Voice: 1st & 2nd Year",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -24583,7 +24829,7 @@
   },
   {
     "code": "MUS091",
-    "title": "Sound, Cognition, and History",
+    "title": "Perception, Mind & Modern Sound",
     "campus": "po",
     "credits": 3.0
   },
@@ -24673,8 +24919,8 @@
   },
   {
     "code": "MUS104",
-    "title": "Music Lit & Analysis Since 1900",
-    "campus": "sc",
+    "title": "Music Since 1900",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -24709,14 +24955,14 @@
   },
   {
     "code": "MUS117",
-    "title": "Twentieth-Century Music",
-    "campus": "sc",
+    "title": "Conducting",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "MUS118",
     "title": "Music in the United States",
-    "campus": "sc",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -24745,14 +24991,14 @@
   },
   {
     "code": "MUS121",
-    "title": "Music of the Spirits",
-    "campus": "sc",
+    "title": "Sem in Music Hist(Before 1750)",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "MUS122",
-    "title": "Color of Mus:Race in Blues/Jazz",
-    "campus": "sc",
+    "title": "Sem in Music Hist (1750-c.1920)",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -24781,8 +25027,8 @@
   },
   {
     "code": "MUS127",
-    "title": "Cultural History of Rap",
-    "campus": "sc",
+    "title": "The Harmony of Sound and Light",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -25141,8 +25387,8 @@
   },
   {
     "code": "MUS179",
-    "title": "Keyboard Instruments for Pianist",
-    "campus": "sc",
+    "title": "Special Topics in Music",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -25165,8 +25411,8 @@
   },
   {
     "code": "MUS180",
-    "title": "Fortepiano",
-    "campus": "sc",
+    "title": "Adv Topics in Music History",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -25189,7 +25435,7 @@
   },
   {
     "code": "MUS184",
-    "title": "Lab, 20th C Music Hist & Theory",
+    "title": "20th C Music History & Theory",
     "campus": "po",
     "credits": 3.0
   },
@@ -25219,8 +25465,8 @@
   },
   {
     "code": "MUS191",
-    "title": "Senior Thesis in Music",
-    "campus": "sc",
+    "title": "Senior Thesis",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -25249,8 +25495,8 @@
   },
   {
     "code": "MUS198",
-    "title": "Independent Internship",
-    "campus": "sc",
+    "title": "Summer Reading & Research",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -25269,6 +25515,12 @@
     "code": "MUS301A",
     "title": "Mus Lit/Historical Styles Analy",
     "campus": "cgu",
+    "credits": 3.0
+  },
+  {
+    "code": "MUSIC",
+    "title": "Lessons/Ensembles for PAC 6",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -25297,13 +25549,13 @@
   },
   {
     "code": "NEUR101",
-    "title": "Lab, Intro to Neuroscience",
+    "title": "Intro to Neuroscience",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "NEUR102",
-    "title": "Lab, Neuroethology",
+    "title": "Neuroethology: Mech Behav w/Lab",
     "campus": "po",
     "credits": 3.0
   },
@@ -25321,7 +25573,7 @@
   },
   {
     "code": "NEUR110",
-    "title": "Lab, Developmental Neurobiology",
+    "title": "Developmental Neurobiology",
     "campus": "po",
     "credits": 3.0
   },
@@ -25339,13 +25591,13 @@
   },
   {
     "code": "NEUR130",
-    "title": "Lab, Vertebrate Sensory Systems",
+    "title": "Vertebrate Sensory Systems w/Lab",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "NEUR143",
-    "title": "Lab, Human Brain",
+    "title": "Human Brain: Neurons-Behav w/Lab",
     "campus": "po",
     "credits": 3.0
   },
@@ -25369,19 +25621,19 @@
   },
   {
     "code": "NEUR168",
-    "title": "Genes and Behavior Lab",
+    "title": "Genes and Behavior w/ Lab",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "NEUR178",
-    "title": "Neurobiology Lab",
+    "title": "Neurobiology with Lab",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "NEUR182",
-    "title": "Machine Learning w Neural Signal",
+    "title": "Network Sci & Machine Learning",
     "campus": "sc",
     "credits": 3.0
   },
@@ -25459,8 +25711,8 @@
   },
   {
     "code": "NEUR191",
-    "title": "Senior Library Thesis",
-    "campus": "po",
+    "title": "One-Sem Thesis in Neuroscience",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -25483,8 +25735,8 @@
   },
   {
     "code": "NEUR198",
-    "title": "Independent Internship",
-    "campus": "sc",
+    "title": "Summer Reading & Research",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -25518,6 +25770,12 @@
     "credits": 3.0
   },
   {
+    "code": "NOTFORUSEHM",
+    "title": "Not Counting in Degree Audit",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "NR001",
     "title": "Strategies for Success",
     "campus": "pz",
@@ -25538,6 +25796,12 @@
   {
     "code": "OCMCAP2",
     "title": "Off-Campus Major Capstone",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "OFFMAJOR",
+    "title": "Off-Campus Major Requirement",
     "campus": "hmc",
     "credits": 3.0
   },
@@ -25609,7 +25873,7 @@
   },
   {
     "code": "ONT170",
-    "title": "Radical Resrch & Social Prtnshps",
+    "title": "Advanced Research Practicum",
     "campus": "pz",
     "credits": 3.0
   },
@@ -25801,7 +26065,7 @@
   },
   {
     "code": "ORST161",
-    "title": "College Inside-Out",
+    "title": "College",
     "campus": "pz",
     "credits": 3.0
   },
@@ -25867,8 +26131,8 @@
   },
   {
     "code": "ORST198",
-    "title": "Independent Internship",
-    "campus": "sc",
+    "title": "Topics in Orgs: Dynamics & Chang",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -25899,6 +26163,24 @@
     "code": "ORST999",
     "title": "Independent Study",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "OVERLAYAD",
+    "title": "Analyzing Difference Overlay",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "OVERLAYSI",
+    "title": "Speaking Intensive Overlay",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "OVERLAYWI",
+    "title": "Writing Intensive Overlay",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -25980,9 +26262,15 @@
     "credits": 3.0
   },
   {
-    "code": "PE001",
-    "title": "Aerobics",
+    "code": "PE",
+    "title": "Physical Ed: Directed Readings",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PE001",
+    "title": "Physical Education Activity",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -25999,8 +26287,8 @@
   },
   {
     "code": "PE002",
-    "title": "Pilates Method",
-    "campus": "po",
+    "title": "Phys. Ed. Teams & Club Sports",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -26011,19 +26299,19 @@
   },
   {
     "code": "PE003",
-    "title": "Introduction to Fitness",
-    "campus": "po",
+    "title": "Physical Fitness for Life",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PE004",
-    "title": "Tough Mudder Training",
-    "campus": "po",
+    "title": "Breakdancing/Hip Hop",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PE004A",
-    "title": "Breakdancing/Hip Hop-Beg/Int",
+    "title": "Breakdancing-Beg/Int",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -26035,8 +26323,8 @@
   },
   {
     "code": "PE006",
-    "title": "Core Training",
-    "campus": "po",
+    "title": "Pure Barre",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -26047,8 +26335,8 @@
   },
   {
     "code": "PE007",
-    "title": "Triathlon Training",
-    "campus": "po",
+    "title": "Aerobics",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -26065,8 +26353,8 @@
   },
   {
     "code": "PE008",
-    "title": "Conditioning - Advanced",
-    "campus": "po",
+    "title": "Fitness Class",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -26089,38 +26377,38 @@
   },
   {
     "code": "PE009",
-    "title": "Jogging/Running",
-    "campus": "po",
+    "title": "Half Marathon Training",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PE010",
-    "title": "Hiking/Geocaching",
-    "campus": "po",
+    "title": "Jogging",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PE011",
-    "title": "Outdoor Leadership",
-    "campus": "po",
+    "title": "Running",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PE011A",
-    "title": "Ropes Course and Leadership Trng",
+    "title": "Ldrshp on the Challenge Course",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "PE012",
-    "title": "Beginning Backpacking",
-    "campus": "po",
+    "title": "Run with the Dean",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PE013",
-    "title": "Aqua Fit",
-    "campus": "po",
+    "title": "Pilates-Reformer Based",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -26143,8 +26431,8 @@
   },
   {
     "code": "PE014",
-    "title": "Beginning Rock Climbing",
-    "campus": "po",
+    "title": "Spinning-Stationary Bike",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -26155,14 +26443,14 @@
   },
   {
     "code": "PE015",
-    "title": "Swim Fitness",
-    "campus": "po",
+    "title": "Swim Conditioning",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PE016",
-    "title": "Weight Training",
-    "campus": "po",
+    "title": "Aqua Fitness",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -26179,8 +26467,8 @@
   },
   {
     "code": "PE017",
-    "title": "Intro to Wilderness Survival",
-    "campus": "po",
+    "title": "Speed and Agility Class",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -26197,8 +26485,8 @@
   },
   {
     "code": "PE018",
-    "title": "Weight Training & Cardio",
-    "campus": "po",
+    "title": "Self-Defense",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -26209,8 +26497,8 @@
   },
   {
     "code": "PE019",
-    "title": "Circuit Strength Training",
-    "campus": "po",
+    "title": "Fitness Bootcamp",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -26227,20 +26515,20 @@
   },
   {
     "code": "PE020",
-    "title": "Cardio and Strength",
-    "campus": "po",
+    "title": "Martial Arts-Intro",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PE020A",
-    "title": "Strength and Conditioning",
-    "campus": "po",
+    "title": "Basic Yi Quan Standing Practice",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PE021",
-    "title": "Yoga - Hatha Method I",
-    "campus": "po",
+    "title": "Aikido Kokikai",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -26275,32 +26563,32 @@
   },
   {
     "code": "PE023",
-    "title": "Yoga - Kundalini",
-    "campus": "po",
+    "title": "Intro to Tae Kwon Do",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PE024",
-    "title": "Running/Interval Training",
-    "campus": "po",
+    "title": "Judo",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PE025",
-    "title": "Introduction to the Weight Room",
-    "campus": "po",
+    "title": "Karate-Shotokan",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PE026",
-    "title": "Shotokan Karate",
-    "campus": "po",
+    "title": "Kung Fu-San Soo",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PE027",
-    "title": "Martial Arts Tai Chi",
-    "campus": "po",
+    "title": "Brazilian Jiu Jitsu",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -26371,8 +26659,8 @@
   },
   {
     "code": "PE032",
-    "title": "Dance - Hip Hop",
-    "campus": "po",
+    "title": "Aerial Circus",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -26383,7 +26671,7 @@
   },
   {
     "code": "PE032B",
-    "title": "Aerial Circus Fitness Bootcamp",
+    "title": "Aerial Circus Workout",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -26407,13 +26695,13 @@
   },
   {
     "code": "PE032F",
-    "title": "Aerial Silks Bootcamp",
+    "title": "Aerial Circus Bootcamp",
     "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PE032G",
-    "title": "Aerial Silks/Trapeze/Hoop",
+    "title": "Aerial Silks/Trapeze/Hoops",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -26443,7 +26731,7 @@
   },
   {
     "code": "PE034",
-    "title": "FitBoxing",
+    "title": "Boxing",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -26485,8 +26773,8 @@
   },
   {
     "code": "PE036",
-    "title": "U-Jam",
-    "campus": "po",
+    "title": "Outdoor Adventure-Rock Climbing",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -26557,8 +26845,8 @@
   },
   {
     "code": "PE040",
-    "title": "Pickleball",
-    "campus": "po",
+    "title": "Archery",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -26599,8 +26887,8 @@
   },
   {
     "code": "PE046",
-    "title": "Archery",
-    "campus": "po",
+    "title": "Floor Hockey",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -26617,8 +26905,8 @@
   },
   {
     "code": "PE048",
-    "title": "Badminton",
-    "campus": "po",
+    "title": "Golf",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -26641,8 +26929,8 @@
   },
   {
     "code": "PE050",
-    "title": "Bowling",
-    "campus": "po",
+    "title": "Horseback Riding",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -26683,8 +26971,8 @@
   },
   {
     "code": "PE056",
-    "title": "Fencing II",
-    "campus": "po",
+    "title": "Soccer Int/Adv",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -26695,20 +26983,20 @@
   },
   {
     "code": "PE057",
-    "title": "Field Hockey",
-    "campus": "po",
+    "title": "Personal Fitness Challenge",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PE058",
-    "title": "Flag Football",
-    "campus": "po",
+    "title": "Team Sports",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PE059",
-    "title": "Team Sports",
-    "campus": "po",
+    "title": "Ping Pong",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -26725,20 +27013,20 @@
   },
   {
     "code": "PE060A",
-    "title": "Golf Beginning",
-    "campus": "po",
+    "title": "Tennis-Beginning",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PE060B",
-    "title": "Golf Beginning/Intermediate",
-    "campus": "po",
+    "title": "Tennis-Intermediate",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PE060C",
-    "title": "Golf - Short Game",
-    "campus": "po",
+    "title": "Tennis-Advanced",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -26767,7 +27055,7 @@
   },
   {
     "code": "PE065",
-    "title": "ACE Health Coach - Exam Prep",
+    "title": "ACE Personal Training Certifcatn",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -26791,14 +27079,14 @@
   },
   {
     "code": "PE068",
-    "title": "Speed Lacrosse",
-    "campus": "po",
+    "title": "Lifeguard/CPR",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PE069",
-    "title": "Soccer",
-    "campus": "po",
+    "title": "Core, Cardio, & More",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -26809,8 +27097,8 @@
   },
   {
     "code": "PE070",
-    "title": "Basketball: 3 on 3",
-    "campus": "po",
+    "title": "Bikram Yoga",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -26827,14 +27115,14 @@
   },
   {
     "code": "PE071",
-    "title": "Racquets Class",
-    "campus": "po",
+    "title": "Bollywood",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PE072",
-    "title": "Squash",
-    "campus": "po",
+    "title": "Capoeira",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -26845,8 +27133,8 @@
   },
   {
     "code": "PE073",
-    "title": "Basketball: Full Court 5 on 5",
-    "campus": "po",
+    "title": "Intro to Meditation",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -26893,14 +27181,14 @@
   },
   {
     "code": "PE075A",
-    "title": "Swimming - Beginning",
-    "campus": "po",
+    "title": "Yoga-Beg Vinyasa Flow",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PE075B",
-    "title": "Swimming - Intermediate",
-    "campus": "po",
+    "title": "Yoga-Restorative",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -27001,8 +27289,8 @@
   },
   {
     "code": "PE078",
-    "title": "Ultimate Frisbee",
-    "campus": "po",
+    "title": "Zumba",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -27013,8 +27301,8 @@
   },
   {
     "code": "PE079",
-    "title": "Volleyball",
-    "campus": "po",
+    "title": "Tumbling-Beg",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -27025,14 +27313,14 @@
   },
   {
     "code": "PE080",
-    "title": "Comm Engagement Lacrosse (CP)",
-    "campus": "po",
+    "title": "Free Weights",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PE081",
-    "title": "Plogging",
-    "campus": "po",
+    "title": "TRX Suspension Training",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -27043,14 +27331,14 @@
   },
   {
     "code": "PE083",
-    "title": "Beach Games/Lawn Sports",
-    "campus": "po",
+    "title": "Weights-Adv/Fitness",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PE084",
-    "title": "Playground Games",
-    "campus": "po",
+    "title": "Weights-Free Weights",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -27061,20 +27349,20 @@
   },
   {
     "code": "PE085",
-    "title": "Adapted Physical Education",
-    "campus": "po",
+    "title": "Olympic Weightlifting",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PE086",
-    "title": "Baseball Analytics",
-    "campus": "po",
+    "title": "Adv Weights & Power Training",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PE087",
-    "title": "Fitness & Wellness",
-    "campus": "po",
+    "title": "Circuit Training",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -27091,20 +27379,20 @@
   },
   {
     "code": "PE090",
-    "title": "CPR/First Aid",
-    "campus": "po",
+    "title": "First Aid/CPR",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PE091",
-    "title": "Care & Prev of Athletic Injuries",
-    "campus": "po",
+    "title": "Sports Event Management",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PE092",
-    "title": "Comm. Emergency Team Response",
-    "campus": "po",
+    "title": "CPR/AED & Wilderness First Aid",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -27145,8 +27433,8 @@
   },
   {
     "code": "PE110",
-    "title": "Vars Team: Football",
-    "campus": "po",
+    "title": "Cross Country Team-M/W",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -27169,8 +27457,8 @@
   },
   {
     "code": "PE120",
-    "title": "Vars Team: Volleyball",
-    "campus": "po",
+    "title": "Football Team",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -27253,8 +27541,8 @@
   },
   {
     "code": "PE150",
-    "title": "Vars Team: Baseball",
-    "campus": "po",
+    "title": "Tennis Team-Men",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -27295,8 +27583,8 @@
   },
   {
     "code": "PE165",
-    "title": "Vars Team: Softball",
-    "campus": "po",
+    "title": "Water Polo Team-Men",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -27397,7 +27685,7 @@
   },
   {
     "code": "PE235",
-    "title": "Soccer Club-Men",
+    "title": "Soccer Club",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -27432,6 +27720,18 @@
     "credits": 3.0
   },
   {
+    "code": "PEELEC",
+    "title": "PE Elective",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PEELECT",
+    "title": "PE Elective Requirement",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
     "code": "PEND000",
     "title": "Pending Registration",
     "campus": "pz",
@@ -27441,6 +27741,18 @@
     "code": "PEND001",
     "title": "Pending Independent Study",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "PEPFL",
+    "title": "Physical Fitness Course",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "PES",
+    "title": "Intercollegiate Sports PE Req",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -27487,8 +27799,8 @@
   },
   {
     "code": "PHIL007",
-    "title": "Introduction to Philosophy",
-    "campus": "pz",
+    "title": "Discovery, Invention & Progress",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -27505,8 +27817,8 @@
   },
   {
     "code": "PHIL030",
-    "title": "Knowledge, Mind & Existence",
-    "campus": "pz",
+    "title": "Intro: Philosophical Questions",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -27517,8 +27829,8 @@
   },
   {
     "code": "PHIL031",
-    "title": "History of Ethics",
-    "campus": "pz",
+    "title": "Ethical Theory:Ancient-Early Mod",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -27529,8 +27841,8 @@
   },
   {
     "code": "PHIL033",
-    "title": "Political Philosophy",
-    "campus": "po",
+    "title": "Intro: Political Philosophy",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -27541,8 +27853,8 @@
   },
   {
     "code": "PHIL034",
-    "title": "Philosophy of Law",
-    "campus": "pz",
+    "title": "Intro: Moral & Political Issues",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -27559,20 +27871,20 @@
   },
   {
     "code": "PHIL037",
-    "title": "Values and the Environment",
-    "campus": "po",
+    "title": "Intro:Happiness, Meaning, Morals",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PHIL038",
-    "title": "Bioethics",
-    "campus": "po",
+    "title": "Intro: Reason and Reality",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PHIL039",
-    "title": "Happiness and the Good Life",
-    "campus": "pz",
+    "title": "Women, Crime and Punishment (CP)",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -27583,14 +27895,14 @@
   },
   {
     "code": "PHIL042",
-    "title": "Modern Philosophy",
-    "campus": "pz",
+    "title": "History of Modern Philosophy",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "PHIL043",
     "title": "Continental Thought",
-    "campus": "pz",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -27727,7 +28039,7 @@
   },
   {
     "code": "PHIL096",
-    "title": "Philosophy of Religion",
+    "title": "God & Phil: A Conflict in Reason",
     "campus": "pz",
     "credits": 3.0
   },
@@ -27787,20 +28099,20 @@
   },
   {
     "code": "PHIL102",
-    "title": "Science and Values",
-    "campus": "po",
+    "title": "Hist of Phil: Modern Era",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "PHIL103",
-    "title": "Philosophy of Science: History",
-    "campus": "pz",
+    "title": "Hist of Phil:Nineteenth Century",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "PHIL104",
-    "title": "Philosophy of Science: Topics",
-    "campus": "pz",
+    "title": "Hist of Phil:Contemporary Period",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -27811,8 +28123,8 @@
   },
   {
     "code": "PHIL106",
-    "title": "Philosophy of Biology",
-    "campus": "po",
+    "title": "Kant",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -27877,8 +28189,8 @@
   },
   {
     "code": "PHIL119",
-    "title": "History of Existentialism",
-    "campus": "sc",
+    "title": "Medieval Thought",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -27889,14 +28201,14 @@
   },
   {
     "code": "PHIL121",
-    "title": "Rationalism",
-    "campus": "pz",
+    "title": "Ethical Theory",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "PHIL122",
-    "title": "Continental Phil of Self & Other",
-    "campus": "pz",
+    "title": "Ethics: Ancient and Modern",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -27907,14 +28219,14 @@
   },
   {
     "code": "PHIL124",
-    "title": "Schools of Cultural Criticism",
-    "campus": "sc",
+    "title": "Morality and Self Interest",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "PHIL125",
-    "title": "Classical Chinese Philosophy",
-    "campus": "sc",
+    "title": "Ethical Issues in Science/Engr",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -27931,8 +28243,8 @@
   },
   {
     "code": "PHIL128",
-    "title": "Practical Rationality",
-    "campus": "po",
+    "title": "The Metaphysics of Persons",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -27943,8 +28255,8 @@
   },
   {
     "code": "PHIL130",
-    "title": "Philosophy of Mind",
-    "campus": "sc",
+    "title": "Political Philosophy",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -27955,8 +28267,8 @@
   },
   {
     "code": "PHIL132",
-    "title": "The Substance of the Soul",
-    "campus": "sc",
+    "title": "Philosophy of Cognitive Science",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -27967,14 +28279,14 @@
   },
   {
     "code": "PHIL134",
-    "title": "Knowledge and Mind",
-    "campus": "sc",
+    "title": "Topics: Metaphysics/Epistemology",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PHIL135",
-    "title": "Philosophy of Mind",
-    "campus": "cmc",
+    "title": "Theories of Justice",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -27986,13 +28298,13 @@
   {
     "code": "PHIL137",
     "title": "Skepticism",
-    "campus": "sc",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PHIL138",
-    "title": "Intro Phil of Language & Mind",
-    "campus": "sc",
+    "title": "ClassclLiberalism/Libertarianism",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -28027,7 +28339,7 @@
   },
   {
     "code": "PHIL149",
-    "title": "Topics in Philosophy",
+    "title": "Phil Topics: Agency & Action",
     "campus": "sc",
     "credits": 3.0
   },
@@ -28057,8 +28369,8 @@
   },
   {
     "code": "PHIL155",
-    "title": "Ethics of Begin & End of Life",
-    "campus": "sc",
+    "title": "Islam vs. Islam",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -28093,8 +28405,8 @@
   },
   {
     "code": "PHIL160",
-    "title": "Ethical Theory",
-    "campus": "sc",
+    "title": "Special Topics in Value Theory",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -28111,14 +28423,14 @@
   },
   {
     "code": "PHIL164",
-    "title": "Seminar: The Moral Deal",
-    "campus": "sc",
+    "title": "Political Phil: Current Debates",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PHIL166",
-    "title": "Rationality in Dispute",
-    "campus": "sc",
+    "title": "The Social Contract Tradition",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -28141,8 +28453,8 @@
   },
   {
     "code": "PHIL170",
-    "title": "Faith and Reason",
-    "campus": "sc",
+    "title": "Great Philosophers",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -28183,8 +28495,8 @@
   },
   {
     "code": "PHIL179",
-    "title": "Greek Moral Philosophy",
-    "campus": "sc",
+    "title": "Special Topics in Philosophy",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -28207,8 +28519,8 @@
   },
   {
     "code": "PHIL179D",
-    "title": "Empirical & Experimental Phil",
-    "campus": "pz",
+    "title": "Empirical/ExperimentalPhilosophy",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -28231,7 +28543,7 @@
   },
   {
     "code": "PHIL183",
-    "title": "Philosophy and Literature",
+    "title": "Aesthetics of Literature",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -28249,8 +28561,8 @@
   },
   {
     "code": "PHIL185A",
-    "title": "Plato",
-    "campus": "sc",
+    "title": "Topics in Metaphysics",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -28261,8 +28573,8 @@
   },
   {
     "code": "PHIL185L",
-    "title": "Topics:Epist Metaphysics & Mind",
-    "campus": "pz",
+    "title": "Topics: Epistem/Metaphysics/Mind",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -28327,7 +28639,7 @@
   },
   {
     "code": "PHIL187",
-    "title": "Environmental Ethics",
+    "title": "Phil Roots of European Fascism",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -28357,14 +28669,14 @@
   },
   {
     "code": "PHIL190",
-    "title": "Senior Seminar in Philosophy",
-    "campus": "sc",
+    "title": "Senior Literature Review",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "PHIL191",
-    "title": "Senior Thesis in Philosophy",
-    "campus": "sc",
+    "title": "Senior Thesis",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -28388,7 +28700,7 @@
   {
     "code": "PHIL199",
     "title": "Independent Study in Philosophy",
-    "campus": "sc",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -28549,7 +28861,7 @@
   },
   {
     "code": "PHYS003",
-    "title": "Lab, Physics of Music",
+    "title": "The Physics of Music",
     "campus": "po",
     "credits": 3.0
   },
@@ -28609,7 +28921,7 @@
   },
   {
     "code": "PHYS030L",
-    "title": "General Physics",
+    "title": "General Physics Life Sciences",
     "campus": "sc",
     "credits": 3.0
   },
@@ -28627,7 +28939,7 @@
   },
   {
     "code": "PHYS031L",
-    "title": "General Physics",
+    "title": "General Physics Life Sciences",
     "campus": "sc",
     "credits": 3.0
   },
@@ -28681,7 +28993,7 @@
   },
   {
     "code": "PHYS042",
-    "title": "Lab, General Physics",
+    "title": "General Physics w/Lab",
     "campus": "po",
     "credits": 3.0
   },
@@ -28765,7 +29077,7 @@
   },
   {
     "code": "PHYS070",
-    "title": "Lab, Spacetime, Quanta, Entropy",
+    "title": "Spacetime, Quanta, Entropy w/Lab",
     "campus": "po",
     "credits": 3.0
   },
@@ -28849,14 +29161,14 @@
   },
   {
     "code": "PHYS100",
-    "title": "Computational Phys/Engineering",
+    "title": "Computatnl Physics+Engineering",
     "campus": "sc",
     "credits": 3.0
   },
   {
     "code": "PHYS101",
-    "title": "Lab, Foundations Modern Physics",
-    "campus": "po",
+    "title": "Classical Mechns Computal Appls",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -28933,7 +29245,7 @@
   },
   {
     "code": "PHYS128",
-    "title": "Lab, Electronics",
+    "title": "Electronics with Laboratory",
     "campus": "po",
     "credits": 3.0
   },
@@ -28993,7 +29305,7 @@
   },
   {
     "code": "PHYS155",
-    "title": "Experimental Optics",
+    "title": "Physical Optics",
     "campus": "po",
     "credits": 3.0
   },
@@ -29047,8 +29359,8 @@
   },
   {
     "code": "PHYS170",
-    "title": "Quantum Mechanics",
-    "campus": "po",
+    "title": "Computational Methods in Physics",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -29059,8 +29371,8 @@
   },
   {
     "code": "PHYS174",
-    "title": "Lab, Contemp Experimental Phys",
-    "campus": "po",
+    "title": "Biophysics",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -29077,8 +29389,8 @@
   },
   {
     "code": "PHYS178",
-    "title": "Biophysics",
-    "campus": "sc",
+    "title": "Special Topics in Physics",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -29197,8 +29509,8 @@
   },
   {
     "code": "PHYS191",
-    "title": "Senior Thesis",
-    "campus": "po",
+    "title": "Research in Physics",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -29221,8 +29533,8 @@
   },
   {
     "code": "PHYS193",
-    "title": "Senior Comprehensive Examination",
-    "campus": "po",
+    "title": "Physics Clinic",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -29251,14 +29563,14 @@
   },
   {
     "code": "PHYS198",
-    "title": "Independent Internship: Physics",
-    "campus": "sc",
+    "title": "Readings in Physics",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "PHYS199",
-    "title": "Independent Study in Physics",
-    "campus": "sc",
+    "title": "Senior Thesis in Physics",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -29286,6 +29598,18 @@
     "credits": 3.0
   },
   {
+    "code": "PHYSELECTHM",
+    "title": "Physics Major Elective",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "POLI",
+    "title": "DEMOCRACY, HUMAN RIGHTS AND USFP",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "POLI001A",
     "title": "Classical Political Theory",
     "campus": "po",
@@ -29305,7 +29629,7 @@
   },
   {
     "code": "POLI003",
-    "title": "Lab, Intro to American Politics",
+    "title": "Intro to American Politics",
     "campus": "po",
     "credits": 3.0
   },
@@ -29497,7 +29821,7 @@
   },
   {
     "code": "POLI098",
-    "title": "Political Journalism",
+    "title": "Summer Reading & Research",
     "campus": "po",
     "credits": 3.0
   },
@@ -29557,38 +29881,38 @@
   },
   {
     "code": "POLI111",
-    "title": "Politics & Markets:Latin America",
-    "campus": "sc",
+    "title": "Green Political Theory",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "POLI112",
-    "title": "Mobilizing Islam",
-    "campus": "sc",
+    "title": "Hannah Arendt",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "POLI113",
-    "title": "People/Power Modern Middle East",
-    "campus": "sc",
+    "title": "Politics of Comedy",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "POLI114",
-    "title": "Islam & Politics in Middle East",
-    "campus": "sc",
+    "title": "The Idea of America",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "POLI115",
-    "title": "Politics of Identity-India",
-    "campus": "sc",
+    "title": "Politics and Literature",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "POLI116",
-    "title": "The Politics of God",
-    "campus": "sc",
+    "title": "American Road Trip",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -29611,7 +29935,7 @@
   },
   {
     "code": "POLI120",
-    "title": "Intro to U.S. Politics",
+    "title": "Intro to American Politics",
     "campus": "sc",
     "credits": 3.0
   },
@@ -29623,8 +29947,8 @@
   },
   {
     "code": "POLI121",
-    "title": "Ending Mass Incarceration",
-    "campus": "sc",
+    "title": "Du Bois: Souls of Black Folk",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -29677,14 +30001,14 @@
   },
   {
     "code": "POLI130",
-    "title": "Intro to Political Economy",
-    "campus": "sc",
+    "title": "Campaigns & Elections",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "POLI131",
-    "title": "Political Economy of Law",
-    "campus": "sc",
+    "title": "American Presidency",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -29695,8 +30019,8 @@
   },
   {
     "code": "POLI133",
-    "title": "Emerging Econ of Europe & Asia",
-    "campus": "sc",
+    "title": "Law and Politics",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -29707,8 +30031,8 @@
   },
   {
     "code": "POLI135",
-    "title": "Political Economy of Food",
-    "campus": "sc",
+    "title": "Policy Implementation/Evaluation",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -29749,8 +30073,8 @@
   },
   {
     "code": "POLI141",
-    "title": "Politics of Race & Amer Pop Film",
-    "campus": "sc",
+    "title": "Corpns & Govts",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -29785,8 +30109,8 @@
   },
   {
     "code": "POLI149",
-    "title": "Sci, Tech & Public Policy",
-    "campus": "po",
+    "title": "Africana Political Theory",
+    "campus": "sc",
     "credits": 3.0
   },
   {
@@ -29845,7 +30169,7 @@
   },
   {
     "code": "POLI160",
-    "title": "Comparative European Politics",
+    "title": "Comparative Politics of Europe",
     "campus": "po",
     "credits": 3.0
   },
@@ -29857,8 +30181,8 @@
   },
   {
     "code": "POLI162",
-    "title": "Political Philosophy",
-    "campus": "sc",
+    "title": "Comparative Politics of Africa",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -29893,7 +30217,7 @@
   },
   {
     "code": "POLI168",
-    "title": "Int'l Relations of East Asia",
+    "title": "International Relations of East",
     "campus": "po",
     "credits": 3.0
   },
@@ -29959,7 +30283,7 @@
   },
   {
     "code": "POLI187",
-    "title": "Special Topics in Politics",
+    "title": "Special Topics in Poli+Intl Rel",
     "campus": "sc",
     "credits": 3.0
   },
@@ -30175,8 +30499,8 @@
   },
   {
     "code": "POLI191",
-    "title": "Sr Thesis: Politics",
-    "campus": "sc",
+    "title": "Senior Thesis",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -30193,8 +30517,8 @@
   },
   {
     "code": "POLI195",
-    "title": "Euro Union Student Scholars Sem",
-    "campus": "sc",
+    "title": "Subfield Specialization",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -30223,7 +30547,7 @@
   },
   {
     "code": "POLI199",
-    "title": "Indep St: Politics & Intl Rel",
+    "title": "Independent Study: Politics",
     "campus": "sc",
     "credits": 3.0
   },
@@ -30253,26 +30577,26 @@
   },
   {
     "code": "PORT001",
-    "title": "Introductory Portuguese 1",
-    "campus": "pz",
+    "title": "Introductory Portuguese I",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PORT002",
-    "title": "Introductory Portuguese 2",
-    "campus": "pz",
+    "title": "Introductory Portuguese II",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PORT022",
     "title": "Intensive Intro Portuguese",
-    "campus": "sc",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PORT033",
     "title": "Intermediate Portuguese",
-    "campus": "pz",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -30319,13 +30643,13 @@
   },
   {
     "code": "POST020",
-    "title": "US Politics: Resistnce & Transfr",
+    "title": "American Politics",
     "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "POST030",
-    "title": "Intro to Comparative Politics",
+    "title": "Comparative Politics",
     "campus": "pz",
     "credits": 3.0
   },
@@ -30349,7 +30673,7 @@
   },
   {
     "code": "POST050",
-    "title": "Politic Thought East&West Intro",
+    "title": "Politial Thought East&West Intro",
     "campus": "pz",
     "credits": 3.0
   },
@@ -30409,7 +30733,7 @@
   },
   {
     "code": "POST100",
-    "title": "Congress and the Presidency",
+    "title": "Legislative Process & Policy",
     "campus": "pz",
     "credits": 3.0
   },
@@ -30421,7 +30745,7 @@
   },
   {
     "code": "POST102",
-    "title": "Women and Public Policy",
+    "title": "Women in Politics",
     "campus": "pz",
     "credits": 3.0
   },
@@ -30481,7 +30805,7 @@
   },
   {
     "code": "POST110",
-    "title": "Politcl Campgn & Mobilztn Stratg",
+    "title": "Government and Pol of the EU",
     "campus": "pz",
     "credits": 3.0
   },
@@ -30517,13 +30841,13 @@
   },
   {
     "code": "POST114",
-    "title": "The Politics of Southeast Asia",
-    "campus": "pz",
+    "title": "Compar Environmental Politics",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "POST115",
-    "title": "Challenges for Dev Democracies",
+    "title": "Democracy and Governance",
     "campus": "pz",
     "credits": 3.0
   },
@@ -30541,7 +30865,7 @@
   },
   {
     "code": "POST118",
-    "title": "The Criminlztn of Latns & Resist",
+    "title": "Teaching & Politics: Praticum",
     "campus": "pz",
     "credits": 3.0
   },
@@ -30571,13 +30895,13 @@
   },
   {
     "code": "POST123",
-    "title": "Building Political Parties",
+    "title": "Post-Soviet Politics",
     "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "POST124",
-    "title": "Chinese Politics",
+    "title": "Comparative Authoritarianism",
     "campus": "pz",
     "credits": 3.0
   },
@@ -30637,7 +30961,7 @@
   },
   {
     "code": "POST134",
-    "title": "Authoritarian Politics",
+    "title": "US Foreign Policy & Mexico",
     "campus": "pz",
     "credits": 3.0
   },
@@ -30859,7 +31183,7 @@
   },
   {
     "code": "POST174",
-    "title": "US Immigration Policy",
+    "title": "US Immigration & Transnatl Poli",
     "campus": "pz",
     "credits": 3.0
   },
@@ -30907,7 +31231,7 @@
   },
   {
     "code": "POST182",
-    "title": "Local Democracy",
+    "title": "Seminar in Minority Politics",
     "campus": "pz",
     "credits": 3.0
   },
@@ -30931,7 +31255,7 @@
   },
   {
     "code": "POST185A",
-    "title": "Logics of Political Auth",
+    "title": "Logics of Political Authority",
     "campus": "pz",
     "credits": 3.0
   },
@@ -30955,8 +31279,8 @@
   },
   {
     "code": "POST188",
-    "title": "The Olympics: History & Politics",
-    "campus": "pz",
+    "title": "Political Innovation",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -30991,7 +31315,7 @@
   },
   {
     "code": "POST193",
-    "title": "The Celtic Tiger",
+    "title": "Science Politics & Alt Medicine",
     "campus": "pz",
     "credits": 3.0
   },
@@ -31003,7 +31327,7 @@
   },
   {
     "code": "POST195",
-    "title": "Sr Sem: Women in Politics",
+    "title": "Sr Sem: Politics of Homelessness",
     "campus": "pz",
     "credits": 3.0
   },
@@ -31027,8 +31351,8 @@
   },
   {
     "code": "POST197",
-    "title": "Science, Politics & Alt Medicine",
-    "campus": "pz",
+    "title": "Indep Study in Political Studies",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -31039,13 +31363,13 @@
   },
   {
     "code": "POST198",
-    "title": "Reproductive Rights",
+    "title": "God in the Barrio",
     "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "POST198C",
-    "title": "SR Sem: US Im Plcy & Trnstl Poli",
+    "title": "Sr Sem: US Imgrtn Plcy & Trns Pl",
     "campus": "pz",
     "credits": 3.0
   },
@@ -31368,6 +31692,12 @@
     "credits": 3.0
   },
   {
+    "code": "PPA",
+    "title": "Pub Pol Analysis: Dir Readings",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "PPA001",
     "title": "Intro to Public Policy Analysis",
     "campus": "po",
@@ -31387,13 +31717,19 @@
   },
   {
     "code": "PPA191",
-    "title": "Sr Thes: Public Policy Analysis",
-    "campus": "sc",
+    "title": "Senior Thesis",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "PPA195",
     "title": "Internship in Public Affairs",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "PPE",
+    "title": "Phil/Poli/Econ:Directed Readings",
     "campus": "po",
     "credits": 3.0
   },
@@ -31471,7 +31807,7 @@
   },
   {
     "code": "PSYC012",
-    "title": "Intro African American Psych",
+    "title": "Intro African Amer Psychology",
     "campus": "pz",
     "credits": 3.0
   },
@@ -31555,7 +31891,7 @@
   },
   {
     "code": "PSYC084",
-    "title": "Psychology of the Chicanx-Latinx",
+    "title": "Psychology of the Chicano/a",
     "campus": "po",
     "credits": 3.0
   },
@@ -31579,8 +31915,8 @@
   },
   {
     "code": "PSYC092",
-    "title": "Research Methods",
-    "campus": "pz",
+    "title": "Social Psychology",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -31609,8 +31945,8 @@
   },
   {
     "code": "PSYC096",
-    "title": "Introduction to Matlab",
-    "campus": "pz",
+    "title": "Neuropsychology",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -31633,8 +31969,8 @@
   },
   {
     "code": "PSYC102",
-    "title": "Psychology of Women",
-    "campus": "sc",
+    "title": "Memory",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -31645,8 +31981,8 @@
   },
   {
     "code": "PSYC103",
-    "title": "Psychological Statistics",
-    "campus": "sc",
+    "title": "Social Psychology",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -31657,20 +31993,20 @@
   },
   {
     "code": "PSYC104",
-    "title": "Research Design in Psychology",
-    "campus": "sc",
+    "title": "Experimental Social Psychology",
+    "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "PSYC104L",
-    "title": "Research Design in Psyc Lab",
-    "campus": "sc",
+    "title": "Expl Social Psychology Lab",
+    "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "PSYC105",
-    "title": "Personality",
-    "campus": "sc",
+    "title": "Child Development",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -31687,20 +32023,20 @@
   },
   {
     "code": "PSYC107",
-    "title": "Theories of Personality",
-    "campus": "pz",
+    "title": "Neuroeconomics",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PSYC108",
-    "title": "Drugs: Brain, Mind & Culture",
-    "campus": "pz",
+    "title": "Intro to Social Psychology",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "PSYC109",
-    "title": "Psychology of Work and Family",
-    "campus": "sc",
+    "title": "Intro to Stats for Psychologists",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -31711,8 +32047,8 @@
   },
   {
     "code": "PSYC110",
-    "title": "Child Development",
-    "campus": "sc",
+    "title": "Research Methods",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -31723,14 +32059,14 @@
   },
   {
     "code": "PSYC111",
-    "title": "Adolescent Development",
-    "campus": "sc",
+    "title": "Physiological Psychology",
+    "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "PSYC111L",
-    "title": "Physiological Psychology Lab",
-    "campus": "pz",
+    "title": "Research Methods Practicum",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -31741,13 +32077,13 @@
   },
   {
     "code": "PSYC112",
-    "title": "Adult Development and Aging",
-    "campus": "sc",
+    "title": "Senior Research Methods",
+    "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "PSYC113",
-    "title": "Psychobiology of Emotion",
+    "title": "Intermediate Statistics",
     "campus": "pz",
     "credits": 3.0
   },
@@ -31759,50 +32095,50 @@
   },
   {
     "code": "PSYC115",
-    "title": "Ethics and the Brain",
-    "campus": "pz",
+    "title": "Psyc & Contemp Social Problems",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PSYC116",
-    "title": "Identity Dev in Minority Childrn",
-    "campus": "sc",
+    "title": "Psyc of Child, Family & Work",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PSYC117",
-    "title": "Children & Families: South Asia",
-    "campus": "pz",
+    "title": "Pract in Mediation & Dispute Res",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PSYC118",
-    "title": "Health Psychology",
-    "campus": "pz",
+    "title": "Seminar:Prejudice/Intergrp Relat",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PSYC119",
-    "title": "Topics in Developmental Psych",
-    "campus": "sc",
+    "title": "Sem:Clinical Research/Assessment",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PSYC120",
-    "title": "Cognitive Development",
-    "campus": "sc",
+    "title": "Sem:Behavr Modification w/Pract",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PSYC121",
-    "title": "Language and the Brain",
-    "campus": "sc",
+    "title": "Cognitive Science",
+    "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "PSYC122",
-    "title": "Cognitive Psychology",
-    "campus": "sc",
+    "title": "Sem:Development Psyc w/Practicum",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -31813,8 +32149,8 @@
   },
   {
     "code": "PSYC123",
-    "title": "Cognitive Neuroscience",
-    "campus": "sc",
+    "title": "Language Development",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -31831,44 +32167,44 @@
   },
   {
     "code": "PSYC125",
-    "title": "Developmental Cog Neuroscience",
-    "campus": "pz",
+    "title": "Culture/Hum Dev:African Diaspora",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "PSYC126",
-    "title": "Language Acquisition",
-    "campus": "sc",
+    "title": "Children & Educational Policy",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PSYC127",
-    "title": "Neuroscience of Decision Making",
-    "campus": "sc",
+    "title": "Language & Cognition",
+    "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "PSYC128",
-    "title": "Psychological Disorders",
+    "title": "Abnormal Psychology",
     "campus": "sc",
     "credits": 3.0
   },
   {
     "code": "PSYC129",
-    "title": "Social Neuroscience",
-    "campus": "sc",
+    "title": "Child Dev in Diverse Contexts",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PSYC130",
-    "title": "Emotion:Persp Exp Psyc & Neuro",
-    "campus": "sc",
+    "title": "Controversies in Human Evolution",
+    "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "PSYC131",
-    "title": "Clinical Neuropsychology",
-    "campus": "sc",
+    "title": "Special Topics in Psychology",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -31879,20 +32215,20 @@
   },
   {
     "code": "PSYC132",
-    "title": "Autism Spectrum",
-    "campus": "sc",
+    "title": "Personality Psychology",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PSYC133",
-    "title": "Emotions & Positive Psychology",
-    "campus": "sc",
+    "title": "Positive Psychology",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PSYC135",
-    "title": "Human Trafficking Overview",
-    "campus": "pz",
+    "title": "Controversies in Cogntv-Neurosci",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -31903,20 +32239,20 @@
   },
   {
     "code": "PSYC138",
-    "title": "Hist and Sci of Innateness",
-    "campus": "pz",
+    "title": "Art & Science of Human Action",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PSYC140",
-    "title": "Psychology of Mindfulness",
-    "campus": "pz",
+    "title": "Leadership",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PSYC141",
-    "title": "Human Neuroscience",
-    "campus": "po",
+    "title": "Leading Entrepreneurial Ventures",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -31927,14 +32263,14 @@
   },
   {
     "code": "PSYC143",
-    "title": "Lab, Neuropsychology",
+    "title": "Neuropsychology w/ Lab",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "PSYC144",
-    "title": "Structural Equation Modeling",
-    "campus": "sc",
+    "title": "Culture & Psychobiology of Pain",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -31945,8 +32281,8 @@
   },
   {
     "code": "PSYC145",
-    "title": "Mixed Methods Research",
-    "campus": "sc",
+    "title": "Psychology of Morality",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -31969,14 +32305,14 @@
   },
   {
     "code": "PSYC150",
-    "title": "Child Psychopathology",
-    "campus": "pz",
+    "title": "Psych of Close Relationships",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "PSYC151",
-    "title": "Experimental Child Psychology",
-    "campus": "pz",
+    "title": "Emotional & Social Intelligence",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -31993,38 +32329,38 @@
   },
   {
     "code": "PSYC153",
-    "title": "Socialization of Gender",
-    "campus": "pz",
+    "title": "Asian American Psychology",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "PSYC154",
-    "title": "Cognitive Development",
-    "campus": "pz",
+    "title": "Sem: Meditation/Mindfulness",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PSYC155",
-    "title": "Behavioral Epigenetics",
-    "campus": "pz",
+    "title": "Eth Minority Psyc & Mental Hlth",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PSYC156",
-    "title": "Native American Psychology",
-    "campus": "sc",
+    "title": "Industrial/Organizational Psych",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "PSYC157",
-    "title": "Lab, Research Design & Method",
+    "title": "Research Design/Methodlgy w/Lab",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "PSYC158",
-    "title": "Lab, Intro Statistics for Psych",
-    "campus": "po",
+    "title": "Cognitive-Behavioral Therapy",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -32035,8 +32371,8 @@
   },
   {
     "code": "PSYC160",
-    "title": "Cognitive Psychology with Lab",
-    "campus": "po",
+    "title": "Environmental Psychology",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -32047,8 +32383,8 @@
   },
   {
     "code": "PSYC162",
-    "title": "Lab, Memory & Language",
-    "campus": "po",
+    "title": "Seminar:Remembering & Forgetting",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -32059,26 +32395,26 @@
   },
   {
     "code": "PSYC163",
-    "title": "Social Psych & the Legal System",
-    "campus": "sc",
+    "title": "Emotion w/ Lab",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "PSYC164",
-    "title": "Forensic Psychology",
-    "campus": "pz",
+    "title": "Autobiographical Memory",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PSYC165",
-    "title": "Trauma and Memory",
-    "campus": "pz",
+    "title": "Critical Thinking",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PSYC166",
-    "title": "Psyc, Sustain & Environ Decision",
-    "campus": "sc",
+    "title": "Legitimacy of the Legal System",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -32113,8 +32449,8 @@
   },
   {
     "code": "PSYC169",
-    "title": "Topics: Stereotyping & Prejudice",
-    "campus": "sc",
+    "title": "The Default Network of the Brain",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -32125,8 +32461,8 @@
   },
   {
     "code": "PSYC170",
-    "title": "Close Relationships-Lifespan",
-    "campus": "sc",
+    "title": "Emotion",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -32143,26 +32479,26 @@
   },
   {
     "code": "PSYC172",
-    "title": "Environmental Psychology",
-    "campus": "sc",
+    "title": "Research Practicum in Psychology",
+    "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "PSYC173",
-    "title": "Organizational Psychology",
-    "campus": "sc",
+    "title": "Asian American Mental Health",
+    "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "PSYC174",
-    "title": "Is Freud Really Dead?",
-    "campus": "sc",
+    "title": "Ethnic Minority Mental Health",
+    "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "PSYC175",
-    "title": "Survey of Clinical Psychology",
-    "campus": "sc",
+    "title": "Seminar:Cognitive Neuroimaging",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -32203,8 +32539,8 @@
   },
   {
     "code": "PSYC179",
-    "title": "Forensic Psychology",
-    "campus": "pz",
+    "title": "Special Topics in Psychology",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -32275,8 +32611,8 @@
   },
   {
     "code": "PSYC180",
-    "title": "Study of Lives",
-    "campus": "pz",
+    "title": "Forensic Psychology",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -32293,7 +32629,7 @@
   },
   {
     "code": "PSYC180C",
-    "title": "Psychology of Climate Change",
+    "title": "Seminar in Cultural Neuroscience",
     "campus": "po",
     "credits": 3.0
   },
@@ -32305,7 +32641,7 @@
   },
   {
     "code": "PSYC180G",
-    "title": "Personality Disorders",
+    "title": "Attachment Theory",
     "campus": "po",
     "credits": 3.0
   },
@@ -32323,13 +32659,13 @@
   },
   {
     "code": "PSYC180L",
-    "title": "Study of Lives Lab",
-    "campus": "pz",
+    "title": "Sem: Asian American Psychology",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "PSYC180M",
-    "title": "Seminar in Cultural Psychology",
+    "title": "Chicano/Latino Cultural Psych",
     "campus": "po",
     "credits": 3.0
   },
@@ -32341,13 +32677,13 @@
   },
   {
     "code": "PSYC180P",
-    "title": "Study of Lives Practicum",
-    "campus": "pz",
+    "title": "Contemporary Prejudice",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "PSYC180S",
-    "title": "Psych of Addictive Behaviors",
+    "title": "Substance Use Disorders",
     "campus": "po",
     "credits": 3.0
   },
@@ -32371,26 +32707,26 @@
   },
   {
     "code": "PSYC181",
-    "title": "Topics in Clinical Psychology",
-    "campus": "sc",
+    "title": "Abnormal Psychology",
+    "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "PSYC182",
-    "title": "Machine Learning w Neural Signal",
-    "campus": "sc",
+    "title": "Black Psychologists: Women",
+    "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "PSYC183",
-    "title": "Data Science Ethics & Justice",
-    "campus": "sc",
+    "title": "Ethnic Psychology Laboratory",
+    "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "PSYC184",
-    "title": "Computational Psychiatry",
-    "campus": "sc",
+    "title": "Consciousness",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -32401,8 +32737,8 @@
   },
   {
     "code": "PSYC185",
-    "title": "IGLAS Seminar",
-    "campus": "pz",
+    "title": "Health Psychology",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -32413,26 +32749,26 @@
   },
   {
     "code": "PSYC186",
-    "title": "Internships in Psychology",
-    "campus": "pz",
+    "title": "Sem: Organizational Development",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PSYC187",
-    "title": "Dialectical Behavior Therapy",
-    "campus": "pz",
+    "title": "Practicum in Org Intervention",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PSYC188",
-    "title": "Seminar Body Weight Reg & Obes",
+    "title": "Seminar in African American Psyc",
     "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "PSYC189",
-    "title": "Ethical Issues in Psychology",
-    "campus": "pz",
+    "title": "Sem in Clinical Psyc w Practicum",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -32515,8 +32851,8 @@
   },
   {
     "code": "PSYC190",
-    "title": "History and Systems in Psych",
-    "campus": "pz",
+    "title": "Advanced Psychology & Law",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -32539,8 +32875,8 @@
   },
   {
     "code": "PSYC191",
-    "title": "Senior Thesis in Psychology",
-    "campus": "sc",
+    "title": "Senior Thesis",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -32581,8 +32917,8 @@
   },
   {
     "code": "PSYC193",
-    "title": "Senior Thesis: Spring",
-    "campus": "sc",
+    "title": "Health Disparities Seminar",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -32593,8 +32929,8 @@
   },
   {
     "code": "PSYC195",
-    "title": "Internship in Psychology",
-    "campus": "sc",
+    "title": "Seminar in Emotional Development",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -32605,8 +32941,8 @@
   },
   {
     "code": "PSYC197",
-    "title": "Seminar in Clinical Psychology",
-    "campus": "pz",
+    "title": "Directed Reading/Research",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -32629,14 +32965,14 @@
   },
   {
     "code": "PSYC198",
-    "title": "Independent Internship",
-    "campus": "sc",
+    "title": "Psych Senior Research Seminar",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "PSYC199",
-    "title": "Independent Study in Psychology",
-    "campus": "sc",
+    "title": "Ind Std: Psychology",
+    "campus": "cgu",
     "credits": 3.0
   },
   {
@@ -32913,6 +33249,18 @@
     "code": "QR800",
     "title": "Quantitative Reasoning Ed Obj",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "REG",
+    "title": "Registration Pending",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "REL",
+    "title": "Hindu Sacred Scriptures",
+    "campus": "cgu",
     "credits": 3.0
   },
   {
@@ -33223,7 +33571,7 @@
   },
   {
     "code": "RLST059",
-    "title": "Dreams and Afterworlds in Islam",
+    "title": "The Afterworld in Islamic Tradtn",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -33235,8 +33583,8 @@
   },
   {
     "code": "RLST061",
-    "title": "New Testament Christian Origins",
-    "campus": "sc",
+    "title": "Religious Autobiography",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -33260,13 +33608,13 @@
   {
     "code": "RLST078",
     "title": "Matriarchal Societies",
-    "campus": "pz",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "RLST080",
-    "title": "Congregations and Community",
-    "campus": "pz",
+    "title": "The Holy Fool:Comic/Ugly/Madness",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -33301,8 +33649,8 @@
   },
   {
     "code": "RLST088",
-    "title": "China: Gender Cosmology & State",
-    "campus": "pz",
+    "title": "Prophets, Kings and Politics",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -33325,7 +33673,7 @@
   },
   {
     "code": "RLST092",
-    "title": "Intro to Early Christianities",
+    "title": "Varieties of Early Christianity",
     "campus": "sc",
     "credits": 3.0
   },
@@ -33355,8 +33703,8 @@
   },
   {
     "code": "RLST097",
-    "title": "Queer African Christianities",
-    "campus": "sc",
+    "title": "Dante's Religious Journey",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -33367,13 +33715,13 @@
   },
   {
     "code": "RLST101A",
-    "title": "The Mahabharata",
+    "title": "Sanskrit & Indian Epics I",
     "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "RLST101B",
-    "title": "Ramayana: Lit/Politics/Culture",
+    "title": "Sanskrit & Indian Epics II",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -33409,7 +33757,7 @@
   },
   {
     "code": "RLST107",
-    "title": "Buddhist Modernity in China",
+    "title": "Making Modern Chinese Buddhism",
     "campus": "po",
     "credits": 3.0
   },
@@ -33445,8 +33793,8 @@
   },
   {
     "code": "RLST113",
-    "title": "God, Darwin, and Design",
-    "campus": "pz",
+    "title": "God, Darwin, Design in America",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -33499,7 +33847,7 @@
   },
   {
     "code": "RLST122",
-    "title": "Arab Cultural Histories",
+    "title": "Biblical Interpretation",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -33517,8 +33865,8 @@
   },
   {
     "code": "RLST128",
-    "title": "The Religion of Islam",
-    "campus": "po",
+    "title": "Religion of Islam",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -33541,8 +33889,8 @@
   },
   {
     "code": "RLST132",
-    "title": "Messiahs and the Millennium",
-    "campus": "po",
+    "title": "Messiahs & the Millennium",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -33566,7 +33914,7 @@
   {
     "code": "RLST137",
     "title": "Jewish-Christian Relations",
-    "campus": "sc",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -33638,7 +33986,7 @@
   {
     "code": "RLST149",
     "title": "Islamic Thought",
-    "campus": "po",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -33745,7 +34093,7 @@
   },
   {
     "code": "RLST165",
-    "title": "Rel. & Politics: Medieval Europe",
+    "title": "Religion & Politics: Europe",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -33769,8 +34117,8 @@
   },
   {
     "code": "RLST167",
-    "title": "Early Christian-Muslim Relations",
-    "campus": "sc",
+    "title": "Thry & Pract: Resist Monoculture",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -33823,8 +34171,8 @@
   },
   {
     "code": "RLST176",
-    "title": "Topics:Feminist NT Contemp Cntxt",
-    "campus": "sc",
+    "title": "Visionaries/Prophets/Leadership",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -33890,12 +34238,12 @@
   {
     "code": "RLST180",
     "title": "Interpreting Religious Worlds",
-    "campus": "sc",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "RLST181",
-    "title": "Prison Punishment Redemption(CP)",
+    "title": "Prison Punishment Redemption",
     "campus": "po",
     "credits": 3.0
   },
@@ -33913,20 +34261,20 @@
   },
   {
     "code": "RLST184",
-    "title": "Queer Theory & the Bible",
-    "campus": "po",
+    "title": "Science and Religion",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "RLST186",
-    "title": "Poetry and the Bible",
-    "campus": "sc",
+    "title": "Research Practicum in Archeology",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "RLST187",
-    "title": "Intrpret Jesus:Global/Gendr Prsp",
-    "campus": "sc",
+    "title": "Queering Religion",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -34016,7 +34364,7 @@
   {
     "code": "RLST190",
     "title": "Senior Seminar",
-    "campus": "pz",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -34027,8 +34375,8 @@
   },
   {
     "code": "RLST191",
-    "title": "Senior Thesis: Religious Studies",
-    "campus": "sc",
+    "title": "Senior Thesis",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -34039,14 +34387,14 @@
   },
   {
     "code": "RLST198",
-    "title": "Independ Intern: Religious St",
-    "campus": "sc",
+    "title": "Summer Reading & Research",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "RLST199",
-    "title": "Independ St: Religious Studies",
-    "campus": "sc",
+    "title": "Independent Study",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -34069,13 +34417,13 @@
   },
   {
     "code": "RUSS001",
-    "title": "Elementary Russian 1",
+    "title": "Elementary Russian",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "RUSS002",
-    "title": "Elementary Russian 2",
+    "title": "Elementary Russian",
     "campus": "po",
     "credits": 3.0
   },
@@ -34123,13 +34471,13 @@
   },
   {
     "code": "RUSS183",
-    "title": "Comedy in Russ Lit and Film",
+    "title": "Russian Comedy in Film & Fiction",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "RUSS184",
-    "title": "The Art of Translation",
+    "title": "Russian Cinema Stalin to Present",
     "campus": "po",
     "credits": 3.0
   },
@@ -34166,7 +34514,7 @@
   {
     "code": "RUSS191",
     "title": "Senior Thesis in Russian",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -34237,13 +34585,13 @@
   },
   {
     "code": "RUST105",
-    "title": "Stranger Than Fiction",
+    "title": "Russian Literature 1861-1917",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "RUST110",
-    "title": "Russian and East European Cinema",
+    "title": "Modernism in Russia & Europe",
     "campus": "po",
     "credits": 3.0
   },
@@ -34279,7 +34627,7 @@
   },
   {
     "code": "RUST175",
-    "title": "Russia: Empire and Identity",
+    "title": "Russia: Empire & Ethnicity",
     "campus": "po",
     "credits": 3.0
   },
@@ -34320,9 +34668,39 @@
     "credits": 3.0
   },
   {
+    "code": "SC",
+    "title": "Scripps Foreign Language GE",
+    "campus": "sc",
+    "credits": 3.0
+  },
+  {
+    "code": "SI",
+    "title": "Speaking Intnsve Req Fulfillment",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "SIOPT",
+    "title": "Speaking Intensive Optional Crs",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "SIOPT-IP",
+    "title": "SI OPTIONAL COURSE-IN PROGRESS",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "SIPZ195",
     "title": "Ctr for Scl Inquiry: Democracies",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "SOC",
+    "title": "Sociology: Directed Readings",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -34333,7 +34711,7 @@
   },
   {
     "code": "SOC003",
-    "title": "Transatlantic Black/Asian Film",
+    "title": "Transatlantic Blk/Asian Film/Lit",
     "campus": "pz",
     "credits": 3.0
   },
@@ -34411,8 +34789,8 @@
   },
   {
     "code": "SOC030",
-    "title": "Deviant Sex Cults?",
-    "campus": "pz",
+    "title": "Chicanos/as Contemp Society (CP)",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -34495,13 +34873,13 @@
   },
   {
     "code": "SOC051",
-    "title": "Caste, Class & Colonialism",
-    "campus": "pz",
+    "title": "Introduction to Sociology",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "SOC055",
-    "title": "Lab, Population Trends & Issues",
+    "title": "Population & the Environment",
     "campus": "po",
     "credits": 3.0
   },
@@ -34567,8 +34945,8 @@
   },
   {
     "code": "SOC075",
-    "title": "American Settler Colonialism",
-    "campus": "pz",
+    "title": "Social and Political Movements",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -34681,8 +35059,8 @@
   },
   {
     "code": "SOC090",
-    "title": "Sociology:Arab-Israeli Coflict",
-    "campus": "pz",
+    "title": "Global Systems and Society",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -34736,7 +35114,7 @@
   {
     "code": "SOC102",
     "title": "Qualitative Research Methods",
-    "campus": "pz",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -34747,8 +35125,8 @@
   },
   {
     "code": "SOC104",
-    "title": "Desiring The Other",
-    "campus": "pz",
+    "title": "Survey & Quant. Research Methods",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -34801,8 +35179,8 @@
   },
   {
     "code": "SOC114",
-    "title": "Sociology of Religion",
-    "campus": "pz",
+    "title": "LA Communities:Trans/Ineq/Actvsm",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -34813,8 +35191,8 @@
   },
   {
     "code": "SOC116",
-    "title": "Women and Law",
-    "campus": "pz",
+    "title": "American Families",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -34825,8 +35203,8 @@
   },
   {
     "code": "SOC118",
-    "title": "Sociology of Secularity",
-    "campus": "pz",
+    "title": "Japanese Families",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -34861,20 +35239,20 @@
   },
   {
     "code": "SOC124",
-    "title": "Race, Place and Space",
-    "campus": "pz",
+    "title": "Global Asia America",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "SOC125",
-    "title": "Workshop in Urban Studies",
-    "campus": "pz",
+    "title": "Power, Politics and Society",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "SOC126",
-    "title": "Race & Family as Organizations",
-    "campus": "pz",
+    "title": "Immigration & Second Generation",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -34891,8 +35269,8 @@
   },
   {
     "code": "SOC130",
-    "title": "Selling Emotions",
-    "campus": "pz",
+    "title": "Sociology of Violence",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -34939,14 +35317,14 @@
   },
   {
     "code": "SOC146",
-    "title": "Sociology of Homelessness",
-    "campus": "pz",
+    "title": "Women's Roles in Society",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "SOC147",
-    "title": "Sociology of Poverty",
-    "campus": "po",
+    "title": "Sport Sociology: Asian Americans",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -34963,7 +35341,7 @@
   },
   {
     "code": "SOC150",
-    "title": "Chicanx/Latinx & Education CP",
+    "title": "Contemporary Asian-Amer Issues",
     "campus": "po",
     "credits": 3.0
   },
@@ -34999,8 +35377,8 @@
   },
   {
     "code": "SOC157",
-    "title": "Gender in American Society",
-    "campus": "pz",
+    "title": "History & Devel Soc Theory II",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -35047,8 +35425,8 @@
   },
   {
     "code": "SOC179",
-    "title": "Social Movements Thru Present",
-    "campus": "pz",
+    "title": "Introduction to Sociology",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -35083,7 +35461,7 @@
   },
   {
     "code": "SOC188",
-    "title": "Seminar: Sex & Religion",
+    "title": "Teaching as Social Change",
     "campus": "pz",
     "credits": 3.0
   },
@@ -35167,14 +35545,14 @@
   },
   {
     "code": "SOC190",
-    "title": "Soc of Palestine-Israel Conflict",
-    "campus": "pz",
+    "title": "Senior Seminar",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "SOC191",
-    "title": "Sr Thesis: Sociology",
-    "campus": "sc",
+    "title": "Senior Thesis",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -35282,19 +35660,19 @@
   {
     "code": "SPAN001",
     "title": "Introductory Spanish",
-    "campus": "sc",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "SPAN002",
-    "title": "Introductory Spanish",
-    "campus": "sc",
+    "title": "Continuing Introductory Spanish",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "SPAN011",
-    "title": "Conversation:Contemporary Span",
-    "campus": "sc",
+    "title": "Spanish Conversation, Intermed",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -35318,7 +35696,7 @@
   {
     "code": "SPAN022",
     "title": "Intensive Introductory Spanish",
-    "campus": "sc",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -35330,7 +35708,7 @@
   {
     "code": "SPAN033",
     "title": "Intermediate Spanish",
-    "campus": "sc",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -35348,7 +35726,7 @@
   {
     "code": "SPAN044",
     "title": "Advanced Spanish",
-    "campus": "sc",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -35365,7 +35743,7 @@
   },
   {
     "code": "SPAN050",
-    "title": "Adv Spanish for Heritge Speakers",
+    "title": "Spanish for Heritage Speakers",
     "campus": "pz",
     "credits": 3.0
   },
@@ -35413,20 +35791,20 @@
   },
   {
     "code": "SPAN100",
-    "title": "Cultural Competence Hlth Profess",
-    "campus": "sc",
+    "title": "Spanish in the Community",
+    "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "SPAN101",
-    "title": "Introduction Literary Analysis",
-    "campus": "sc",
+    "title": "Intro to Literary Analysis",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "SPAN102",
-    "title": "Latin American Culture & Civ",
-    "campus": "sc",
+    "title": "Intro Lat-Am Cultural Studies",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -35437,14 +35815,14 @@
   },
   {
     "code": "SPAN103",
-    "title": "Adv Conversation and Composition",
-    "campus": "sc",
+    "title": "Queer Fictions & Realities",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "SPAN104",
-    "title": "Public Health in Latin America",
-    "campus": "pz",
+    "title": "Humor in Hispanic Literature",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -35510,13 +35888,13 @@
   {
     "code": "SPAN120A",
     "title": "Survey of Spanish Literature",
-    "campus": "sc",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "SPAN120B",
-    "title": "Survey of Spanish Literature",
-    "campus": "sc",
+    "title": "Survey of Spanish Literature II",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -35533,20 +35911,20 @@
   },
   {
     "code": "SPAN124",
-    "title": "Language in Spain",
-    "campus": "po",
+    "title": "Visions of Democracy",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "SPAN125A",
-    "title": "Blood & Guts:Decadent Naturalism",
-    "campus": "po",
+    "title": "Intro to Latin-Amer Lit & Civ I",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "SPAN125B",
-    "title": "Survey of Spanish American Lit",
-    "campus": "po",
+    "title": "Intro to Latin-Amer Lit & Civ II",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -35557,20 +35935,20 @@
   },
   {
     "code": "SPAN127",
-    "title": "Spanish Phonetics and Phonology",
-    "campus": "po",
+    "title": "Literatura Chicana en Espanol",
+    "campus": "sc",
     "credits": 3.0
   },
   {
     "code": "SPAN128",
-    "title": "Poverty, Lit & Social Justice",
-    "campus": "po",
+    "title": "Hispanic/Latino Lit in New York",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "SPAN129",
-    "title": "Early Modern Women Writers",
-    "campus": "po",
+    "title": "The Latin American City",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -35599,14 +35977,14 @@
   },
   {
     "code": "SPAN135",
-    "title": "Los Angeles: La Ciudad, su Gente",
-    "campus": "pz",
+    "title": "The Boom:Modern Latin Amer Novel",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "SPAN137",
-    "title": "Translating the Aztecs",
-    "campus": "sc",
+    "title": "Strategies of Resistance in Lat",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -35617,8 +35995,8 @@
   },
   {
     "code": "SPAN140",
-    "title": "Spanish Transition Almodovar",
-    "campus": "sc",
+    "title": "National Identity Discourses",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -35653,8 +36031,8 @@
   },
   {
     "code": "SPAN150",
-    "title": "In Quest of God in Latin America",
-    "campus": "pz",
+    "title": "Identity/Nation 19th C Span-Amer",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -35665,56 +36043,56 @@
   },
   {
     "code": "SPAN152",
-    "title": "Border Thinking in Spain",
-    "campus": "sc",
+    "title": "Gender in 19th-C Spanish-America",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "SPAN153",
-    "title": "Spanglish in Context",
-    "campus": "po",
+    "title": "Pol/Soc Leadership in Latin Amer",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "SPAN154",
-    "title": "Trans-Caribbean Formations",
-    "campus": "sc",
-    "credits": 3.0
-  },
-  {
-    "code": "SPAN155",
-    "title": "Short Fiction by Spanish Women",
-    "campus": "sc",
-    "credits": 3.0
-  },
-  {
-    "code": "SPAN156",
-    "title": "Revisit Latin Amer Short Story",
-    "campus": "sc",
-    "credits": 3.0
-  },
-  {
-    "code": "SPAN157",
-    "title": "19C Latin American Literature",
-    "campus": "sc",
-    "credits": 3.0
-  },
-  {
-    "code": "SPAN158",
-    "title": "Banana Republics",
+    "title": "Latinas in the Garment Industry",
     "campus": "pz",
     "credits": 3.0
   },
   {
+    "code": "SPAN155",
+    "title": "Latin American Short Story",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN156",
+    "title": "Ella y El:Gender in LatinAmerica",
+    "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN157",
+    "title": "Hist Memory & Nostalgia Span-Amr",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
+    "code": "SPAN158",
+    "title": "Revolutions & Thought in Span-Am",
+    "campus": "cmc",
+    "credits": 3.0
+  },
+  {
     "code": "SPAN159",
-    "title": "Multilingual Spain",
-    "campus": "po",
+    "title": "Contemp. Latin American Novel",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "SPAN160",
-    "title": "Jews, Moors, Indians:Span Empire",
-    "campus": "sc",
+    "title": "Nation & Novel: 20th C. Spain",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -35725,14 +36103,14 @@
   },
   {
     "code": "SPAN162",
-    "title": "Journalism in Latin America",
-    "campus": "pz",
+    "title": "Space Power Privilege Cont Spain",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "SPAN163",
-    "title": "Pais Vasco or Euskal Herria",
-    "campus": "sc",
+    "title": "Afrolatinidades",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -35761,14 +36139,14 @@
   },
   {
     "code": "SPAN174",
-    "title": "Lost in Translation",
-    "campus": "pz",
+    "title": "Fictional Families",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "SPAN175",
-    "title": "Aftermath of Spanish Civil War",
-    "campus": "sc",
+    "title": "Romantics & Realists:19thC Lit",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -35785,20 +36163,20 @@
   },
   {
     "code": "SPAN178",
-    "title": "Spanish Civil War Representatns",
-    "campus": "sc",
+    "title": "The New Latin American Cinema",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "SPAN179",
-    "title": "Women Writers of Hispanic World",
-    "campus": "sc",
+    "title": "Mexican Cinema in New Millennium",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "SPAN180",
-    "title": "Spanish Literature 1898-1936",
-    "campus": "po",
+    "title": "Spanish Literature 1898-1920",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -35809,20 +36187,20 @@
   },
   {
     "code": "SPAN182",
-    "title": "Reading the Hispanic Caribbean",
-    "campus": "sc",
+    "title": "Latin-Amer Documentary Cinema",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
     "code": "SPAN183",
-    "title": "Intercul & Bilingualism in Andes",
-    "campus": "sc",
+    "title": "Pre-Hispanic Oral Trad - Mexico",
+    "campus": "pz",
     "credits": 3.0
   },
   {
     "code": "SPAN184",
-    "title": "The Image and the Word",
-    "campus": "sc",
+    "title": "Lit of the Zapatista Rebellion",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -35851,8 +36229,8 @@
   },
   {
     "code": "SPAN189",
-    "title": "Contemp Issues Span-Speak World",
-    "campus": "pz",
+    "title": "Spanish Across the Curriculum",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -35863,8 +36241,8 @@
   },
   {
     "code": "SPAN191",
-    "title": "Senior Thesis in Spanish",
-    "campus": "sc",
+    "title": "Senior Thesis",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -35881,14 +36259,14 @@
   },
   {
     "code": "SPAN198",
-    "title": "Independent Internship",
-    "campus": "sc",
+    "title": "Summer Reading & Research",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "SPAN199",
     "title": "Independent Study in Spanish",
-    "campus": "sc",
+    "campus": "cmc",
     "credits": 3.0
   },
   {
@@ -36060,9 +36438,21 @@
     "credits": 3.0
   },
   {
-    "code": "STS001",
-    "title": "Intro to Sci, Tech, & Society",
+    "code": "SSCONC",
+    "title": "Social Science Conc",
+    "campus": "hmc",
+    "credits": 3.0
+  },
+  {
+    "code": "STS",
+    "title": "Sci Tech Soc: Directed Readings",
     "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "STS001",
+    "title": "Intro to Sci, Tech, and Society",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -36085,14 +36475,14 @@
   },
   {
     "code": "STS081",
-    "title": "Sci & Tech in the Early Modern",
-    "campus": "pz",
+    "title": "History of Science & Technology",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "STS082",
-    "title": "Modern Science",
-    "campus": "pz",
+    "title": "History of Science & Technology",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -36199,14 +36589,14 @@
   },
   {
     "code": "STS190",
-    "title": "Senior Thesis",
-    "campus": "pz",
+    "title": "Senior Seminar: Sci,Tech,Society",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "STS191",
-    "title": "Sr Thesis:Sci,Technology+Society",
-    "campus": "sc",
+    "title": "Senior Thesis",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -36217,8 +36607,8 @@
   },
   {
     "code": "STS198",
-    "title": "Independ Intern:Sci,Tech+Society",
-    "campus": "sc",
+    "title": "Summer Reading & Research",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -36259,26 +36649,26 @@
   },
   {
     "code": "TEST001",
-    "title": "Test lab course for con-rec test",
-    "campus": "po",
+    "title": "Test Course for Web-Reg Testing",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "TEST002",
-    "title": "Test Course at Scripps",
-    "campus": "sc",
+    "title": "Test Course for Web-Reg - PERM",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "TEST003",
-    "title": "Test Course at Scripps",
-    "campus": "sc",
+    "title": "Test Course for web-reg - PERM",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
     "code": "TEST004",
-    "title": "Test Course at Scripps",
-    "campus": "sc",
+    "title": "Pre-req testing course",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -36289,14 +36679,14 @@
   },
   {
     "code": "TEST006",
-    "title": "Test Course at Scripps",
-    "campus": "sc",
+    "title": "Test Course 6",
+    "campus": "po",
     "credits": 3.0
   },
   {
     "code": "TEST007",
-    "title": "Test Course at Scripps",
-    "campus": "sc",
+    "title": "repeat test course",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -36409,7 +36799,7 @@
   },
   {
     "code": "THEA012",
-    "title": "Intermediate Acting Lab",
+    "title": "Inter Acting: Scene Study, Voice",
     "campus": "po",
     "credits": 3.0
   },
@@ -36439,7 +36829,7 @@
   },
   {
     "code": "THEA022",
-    "title": "Lighting & Projection Technology",
+    "title": "Stage Lighting Technology",
     "campus": "po",
     "credits": 3.0
   },
@@ -36451,7 +36841,7 @@
   },
   {
     "code": "THEA024",
-    "title": "Theatrical Sound Technology",
+    "title": "Sound for the Theatre",
     "campus": "po",
     "credits": 3.0
   },
@@ -36565,37 +36955,37 @@
   },
   {
     "code": "THEA060",
-    "title": "Theatre for Young Audiences (CP)",
+    "title": "Theatre for Young Audiences",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "THEA061",
-    "title": "Theatre for Young Audiences (CP)",
+    "title": "Theatre for Young Audiences",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "THEA080",
-    "title": "Lab:Scene Design Stage & Screen",
+    "title": "Scene Design for Stage & Screen",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "THEA081",
-    "title": "Costume Design Lab",
+    "title": "Costume Design Stage & Screen",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "THEA082",
-    "title": "The Magic of Theatrical Light",
+    "title": "Lighting Design Stage and Screen",
     "campus": "po",
     "credits": 3.0
   },
   {
     "code": "THEA083",
-    "title": "Sound Design",
+    "title": "Sound Design-Stage and Screen",
     "campus": "po",
     "credits": 3.0
   },
@@ -36739,7 +37129,7 @@
   },
   {
     "code": "THEA130",
-    "title": "Lab, Introduction to Directing",
+    "title": "Introduction to Directing",
     "campus": "po",
     "credits": 3.0
   },
@@ -37002,15 +37392,63 @@
     "credits": 3.0
   },
   {
+    "code": "WAIVED",
+    "title": "Waived Requirement",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "WGS330",
     "title": "Women of Color Feminisms",
     "campus": "cgu",
     "credits": 3.0
   },
   {
+    "code": "WI",
+    "title": "Wrtng Intnsve Req Fulfilled",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "WI-SI",
+    "title": "Speaking/Writing Int Req Fulfill",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "WI/SI",
+    "title": "Writing&Speaking Intensive Reqs",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
     "code": "WI800",
     "title": "Writing Intensive Educ Objective",
     "campus": "pz",
+    "credits": 3.0
+  },
+  {
+    "code": "WIJRWVR",
+    "title": "Transfer Junior Writ Int Waiver",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "WIOPT",
+    "title": "Writing Intnsv 0ptional Course",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "WIOPT-IP",
+    "title": "WI OPTIONAL COURSE-IN PROGRESS",
+    "campus": "po",
+    "credits": 3.0
+  },
+  {
+    "code": "WOODSHOLEHM",
+    "title": "Woods Hole Environmental Science",
+    "campus": "hmc",
     "credits": 3.0
   },
   {
@@ -37141,8 +37579,8 @@
   },
   {
     "code": "WRIT100",
-    "title": "Advanced Argumentative Writing",
-    "campus": "sc",
+    "title": "Teaching & Tutoring Writing",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -37225,8 +37663,8 @@
   },
   {
     "code": "WRIT140",
-    "title": "Creative Nonfiction",
-    "campus": "sc",
+    "title": "Art & Craft of the Short Story",
+    "campus": "pz",
     "credits": 3.0
   },
   {
@@ -37249,7 +37687,7 @@
   },
   {
     "code": "WRIT175",
-    "title": "Social Action Writing & Rhetoric",
+    "title": "Protest Writing and Rhetoric",
     "campus": "sc",
     "credits": 3.0
   },
@@ -37285,7 +37723,7 @@
   },
   {
     "code": "WRIT197H",
-    "title": "Spec Topics: Investigative Fict",
+    "title": "Topics: The Point of Departure",
     "campus": "sc",
     "credits": 3.0
   },
@@ -37345,8 +37783,8 @@
   },
   {
     "code": "WRIT199",
-    "title": "Independent Study in Writing",
-    "campus": "sc",
+    "title": "Independent Study: Writing",
+    "campus": "po",
     "credits": 3.0
   },
   {
@@ -37483,7 +37921,7 @@
   },
   {
     "code": "XCLA191",
-    "title": "Sr Research in Classical Studies",
+    "title": "Sr Research Classical Studies",
     "campus": "cmc",
     "credits": 3.0
   },
@@ -37867,7 +38305,7 @@
   },
   {
     "code": "XMDS190",
-    "title": "Senior Thesis in Media Studies",
+    "title": "Sr Thesis in Media Studies",
     "campus": "cmc",
     "credits": 3.0
   },


### PR DESCRIPTION
Fixed a bug that prevented the filter from prioritizing HMC duplicate courses. Filters the courses based on their course code and title, which allows users to select between courses codes that corresponded to multiple different courses. The new `allCourses.json` reflects those changes